### PR TITLE
Moved hydrologicals leaf piles into the grass category

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -115,7 +115,7 @@ snowyspirit:wild_ginger \
 \
 festive_delight:cinnamon_bushripe:half=lower \
 \
-hydrol:dry_grass:half=bottom \
+hydrol:spruce_leaves_pile hydrol:jungle_leaves_pile hydrol:acacia_leaves_pile hydrol:mangrove_leaves_pile hydrol:cherry_leaves_pile hydrol:oak_leaves_pile hydrol:dark_oak_leaves_pile hydrol:birch_leaves_pile hydrol:azalea_leaves_pile hydrol:flowering_azalea_leaves_pile hydrol:dry_grass:half=bottom \
 \
 quark:blue_blossom_sapling quark:lavender_blossom_sapling quark:orange_blossom_sapling quark:pink_blossom_sapling quark:yellow_blossom_sapling quark:red_blossom_sapling quark:ancient_sapling \
 \
@@ -193,7 +193,7 @@ farmersdelight:cabbages farmersdelight:tomatoes farmersdelight:onions farmersdel
 # Leaves - Not affected by Euphoria Patches Seasons (Don't tint in Autumn, get snow in winter)
 block.10007 = spruce_leaves jungle_leaves acacia_leaves mangrove_leaves cherry_leaves \
 \
-hydrol:spruce_leaves_wall hydrol:jungle_leaves_wall hydrol:acacia_leaves_wall hydrol:mangrove_leaves_wall hydrol:cherry_leaves_wall hydrol:spruce_leaves_pile hydrol:jungle_leaves_pile hydrol:acacia_leaves_pile hydrol:mangrove_leaves_pile hydrol:cherry_leaves_pile \
+hydrol:spruce_leaves_wall hydrol:jungle_leaves_wall hydrol:acacia_leaves_wall hydrol:mangrove_leaves_wall hydrol:cherry_leaves_wall \
 \
 betternether:willow_leaves betternether:rubeus_leaves betternether:anchor_tree_leaves betternether:black_bush \
 \
@@ -202,7 +202,7 @@ betterend:lucernia_outer_leaves betterend:lucernia_leaves betterend:cave_bush be
 # Leaves
 block.10009 = leaves leaves2 oak_leaves birch_leaves dark_oak_leaves azalea_leaves \
 \
-hydrol:oak_leaves_wall hydrol:dark_oak_leaves_wall hydrol:birch_leaves_wall hydrol:azalea_leaves_wall hydrol:oak_leaves_pile hydrol:dark_oak_leaves_pile hydrol:birch_leaves_pile hydrol:azalea_leaves_pile \
+hydrol:oak_leaves_wall hydrol:dark_oak_leaves_wall hydrol:birch_leaves_wall hydrol:azalea_leaves_wall \
 \
 wondrouswilds:yellow_birch_leaves wondrouswilds:orange_birch_leaves wondrouswilds:red_birch_leaves \
 \
@@ -259,7 +259,7 @@ theabyss:blaru_leaves theabyss:jungle_leaves theabyss:frozen_leaves
 # Leaves - Euphoria Patches Emissive Flowers 
 block.10011 = flowering_azalea_leaves \
 \
-hydrol:flowering_azalea_leaves_wall hydrol:flowering_azalea_leaves_pile \
+hydrol:flowering_azalea_leaves_wall \
 \
 deep_aether:flowering_roseroot_leaves deep_aether:flowering_blue_roseroot_leaves
 


### PR DESCRIPTION
This is so they move when you walk through them, which looks better.