### PR TITLE
Additions and fixes for numerous mods in block.properties

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -67,13 +67,15 @@ byg:yellow_tulip byg:yellow_daffodil byg:winter_scilla byg:winter_rose byg:winte
 \
 biomesoplenty:burning_blossom biomesoplenty:clover biomesoplenty:huge_clover_petal biomesoplenty:rose biomesoplenty:violet biomesoplenty:tall_lavender:half=lower biomesoplenty:wildflower biomesoplenty:icy_iris:half=lower biomesoplenty:glowflower biomesoplenty:pink_hibiscus biomesoplenty:pink_daffodil biomesoplenty:cattail:half=lower biomesoplenty:wilted_lily biomesoplenty:barley:half=lower biomesoplenty:blue_hydrangea:half=lower biomesoplenty:pink_hibiscus biomesoplenty:orange_cosmos biomesoplenty:sprout biomesoplenty:goldenrod:half=lower biomesoplenty:sea_oats:half=lower biomesoplenty:lavender biomesoplenty:tall_white_lavender:half=lower biomesoplenty:white_lavender biomesoplenty:endbloom biomesoplenty:white_petals \
 \
-meadow:enzian meadow:delphinium meadow:alpine_poppy meadow:eriophorum \
+meadow:pine_sapling meadow:eriophorum meadow:fire_lily meadow:enzian meadow:saxifrage meadow:delphinium meadow:alpine_poppy meadow:eriophorum_tall:half=lower meadow:small_fir:half=lower \
 \
 wondrouswilds:purple_violet wondrouswilds:pink_violet wondrouswilds:red_violet wondrouswilds:white_violet \
 \
 terrestria:aloe_vera terrestria:agave terrestria:monsteras terrestria:indian_paintbrush \
 \
 aether:berry_bush_stem aether:purple_flower aether:white_flower \
+\
+friendsandfoes:buttercup \
 \
 biomemakeover:black_thistle:half=lower biomemakeover:foxglove:half=lower biomemakeover:reed:half=lower biomemakeover:barrel_cactus_flowered \
 \
@@ -101,19 +103,37 @@ aether:purple_flower aether:white_flower \
 \
 ancient_aether:highland_viola ancient_aether:sky_blues ancient_aether:wynd_thistle ancient_aether:sakura_blossoms ancient_aether:trapped_sakura_blossoms \
 \
-aether_redux:wyndsprouts aether_redux:skysprouts aether_redux:fieldsproot_petals aether_redux:iridia aether_redux:xaelia_flowers aether_redux:aurum aether_redux:golden_clover aether_redux:zyatrix
+aether_redux:wyndsprouts aether_redux:skysprouts aether_redux:fieldsproot_petals aether_redux:iridia aether_redux:xaelia_flowers aether_redux:aurum aether_redux:golden_clover aether_redux:zyatrix \
+\
+verdantvibes:periwinkle verdantvibes:candy_tuft verdantvibes:lobelia verdantvibes:money_tree verdantvibes:parlour_palm verdantvibes:monstera
 
 #if MC_VERSION >= 11300
 # Short Foliage / Foliage Lower Half - 1.13+
 block.10005 = grass short_grass fern oak_sapling spruce_sapling birch_sapling jungle_sapling acacia_sapling dark_oak_sapling bamboo_sapling cherry_sapling dead_bush wither_rose sweet_berry_bush wheat carrots potatoes beetroots pumpkin_stem melon_stem nether_sprouts warped_roots tall_grass:half=lower large_fern:half=lower \
 \
-farmersdelight:cabbages farmersdelight:tomatoes farmersdelight:onions farmersdelight:wild_cabbages farmersdelight:wild_onions farmersdelight:wild_tomatoes farmersdelight:wild_carrots farmersdelight:wild_potatoes farmersdelight:wild_beetroots farmersdelight:wild_rice:half=lower farmersdelight:rice \
+bakery:strawberry_crop bakery:oat_crop bakery:wild_strawberries \
+\
+beachparty:palm_sapling \
+\
+brewery:barley_crop brewery:corn_crop brewery:hops_crop_body brewery:wild_hops:half=lower \
+\
+candlelight:rose candlelight:wild_tomatoes candlelight:wild_lettuce candlelight:tomato_crop candlelight:lettuce_crop \
+\
+create_bic_bit:sunflowerstem \
+\
+farmersdelight:sandy_shrub farmersdelight:cabbages farmersdelight:tomatoes farmersdelight:onions farmersdelight:wild_cabbages farmersdelight:wild_onions farmersdelight:wild_tomatoes farmersdelight:wild_carrots farmersdelight:wild_potatoes farmersdelight:wild_beetroots farmersdelight:wild_rice:half=lower farmersdelight:rice \
 \
 supplementaries:flax:half=lower supplementaries:wild_flax \
 \
-snowyspirit:wild_ginger \
+snowyspirit:wild_ginger snowyspirit:ginger \
 \
 festive_delight:cinnamon_bushripe:half=lower \
+\
+galosphere:bowl_lichen galosphere:lichen_roots \
+\
+hauntedharvest:corn_base \
+\
+herbalbrews:yerba_mate_plant herbalbrews:rooibos_plant herbalbrews:tea_plant herbalbrews:lavender herbalbrews:hibiscus herbalbrews:wild_rooibos_plant herbalbrews:wild_yerba_mate_plant herbalbrews:wild_coffee_plant \
 \
 hydrol:dry_grass:half=bottom \
 \
@@ -123,7 +143,9 @@ betternether:agave betternether:nether_grass betternether:swamp_grass betterneth
 \
 betterend:chorus_grass betterend:cave_grass betterend:crystal_grass betterend:shadow_plant betterend:bushy_grass betterend:amber_grass betterend:jungle_grass betterend:blooming_cooksonia betterend:salteago betterend:vaiolush_fern betterend:fracturn betterend:globulagus betterend:clawfern betterend:orango betterend:lutebus betterend:lamellarium betterend:aeridium betterend:inflexia betterend:amber_root_seed betterend:chorus_mushroom_seed betterend:filalux_wings:facing=up betterend:blue_vine_seed betterend:needlegrass betterend:end_lotus_seed betterend:lanceleaf_seed betterend:end_lily_seed betterend:umbrella_tree_sapling betterend:helix_tree_sapling betterend:tenanea_sapling betterend:dragon_tree_sapling betterend:lacugrove_sapling betterend:lucernia_sapling betterend:pythadendron_sapling \
 \
-regions_unexplored:stone_bud regions_unexplored:steppe_shrub regions_unexplored:steppe_grass regions_unexplored:small_desert_shrub regions_unexplored:frozen_grass regions_unexplored:dead_steppe_shrub regions_unexplored:prismoss_sprout regions_unexplored:ashen_grass regions_unexplored:mycotoxic_grass regions_unexplored:glistering_fern regions_unexplored:glistering_sprout regions_unexplored:cobalt_roots regions_unexplored:brimsprout regions_unexplored:clover regions_unexplored:cobalt_earlight regions_unexplored:white_snowbelle regions_unexplored:light_gray_snowbelle regions_unexplored:gray_snowbelle regions_unexplored:red_snowbelle regions_unexplored:orange_snowbelle regions_unexplored:yellow_snowbelle regions_unexplored:lime_snowbelle regions_unexplored:green_snowbelle regions_unexplored:cyan_snowbelle regions_unexplored:light_blue_snowbelle regions_unexplored:blue_snowbelle regions_unexplored:purple_snowbelle regions_unexplored:magenta_snowbelle regions_unexplored:pink_snowbelle regions_unexplored:brown_snowbelle regions_unexplored:black_snowbelle regions_unexplored:ashen_sapling regions_unexplored:alpha_sapling regions_unexplored:apple_oak_sapling regions_unexplored:bamboo_sapling regions_unexplored:baobab_sapling regions_unexplored:blackwood_sapling regions_unexplored:cactus_flower regions_unexplored:magnolia_sapling regions_unexplored:cypress_sapling regions_unexplored:dead_pine_sapling regions_unexplored:dead_sapling regions_unexplored:eucalyptus_sapling regions_unexplored:flowering_sapling regions_unexplored:golden_larch_sapling regions_unexplored:joshua_sapling regions_unexplored:kapok_sapling regions_unexplored:larch_sapling regions_unexplored:maple_sapling regions_unexplored:mauve_sapling regions_unexplored:orange_maple_sapling regions_unexplored:palm_sapling regions_unexplored:pine_sapling regions_unexplored:blue_magnolia_sapling regions_unexplored:pink_magnolia_sapling regions_unexplored:redwood_sapling regions_unexplored:red_maple_sapling regions_unexplored:brimwood_sapling regions_unexplored:cobalt_sapling regions_unexplored:enchanted_birch_sapling regions_unexplored:small_oak_sapling regions_unexplored:silver_birch_sapling regions_unexplored:socotra_sapling regions_unexplored:white_magnolia_sapling regions_unexplored:willow_sapling regions_unexplored:acacia_shrub regions_unexplored:baobab_shrub regions_unexplored:birch_shrub regions_unexplored:blackwood_shrub regions_unexplored:brimwood_shrub regions_unexplored:magnolia_shrub regions_unexplored:cherry_shrub regions_unexplored:cypress_shrub regions_unexplored:dark_oak_shrub regions_unexplored:dead_pine_shrub regions_unexplored:dead_shrub regions_unexplored:eucalyptus_shrub regions_unexplored:flowering_shrub regions_unexplored:golden_larch_shrub regions_unexplored:joshua_shrub regions_unexplored:jungle_shrub regions_unexplored:kapok_shrub regions_unexplored:larch_shrub regions_unexplored:mangrove_shrub regions_unexplored:maple_shrub regions_unexplored:mauve_shrub regions_unexplored:oak_shrub regions_unexplored:orange_maple_shrub regions_unexplored:palm_shrub regions_unexplored:pine_shrub regions_unexplored:blue_magnolia_shrub regions_unexplored:pink_magnolia_shrub regions_unexplored:redwood_shrub regions_unexplored:red_maple_shrub regions_unexplored:enchanted_birch_shrub regions_unexplored:silver_birch_shrub regions_unexplored:socotra_shrub regions_unexplored:spruce_shrub regions_unexplored:white_magnolia_shrub regions_unexplored:willow_shrub \
+regions_unexplored:sandy_grass regions_unexplored:salmonberry_bush regions_unexplored:dead_steppe_shrub regions_unexplored:small_desert_shrub regions_unexplored:medium_grass regions_unexplored:bladed_grass regions_unexplored:bladed_tall_grass:half=lower regions_unexplored:stone_bud regions_unexplored:steppe_grass regions_unexplored:steppe_shrub regions_unexplored:frozen_grass regions_unexplored:prismoss_sprout regions_unexplored:ashen_grass regions_unexplored:mycotoxic_grass regions_unexplored:glistering_fern regions_unexplored:glistering_bloom regions_unexplored:glistering_sprout regions_unexplored:cobalt_roots regions_unexplored:brimsprout regions_unexplored:clover regions_unexplored:cobalt_earlight regions_unexplored:white_snowbelle regions_unexplored:light_gray_snowbelle regions_unexplored:gray_snowbelle regions_unexplored:red_snowbelle regions_unexplored:orange_snowbelle regions_unexplored:yellow_snowbelle regions_unexplored:lime_snowbelle regions_unexplored:green_snowbelle regions_unexplored:cyan_snowbelle regions_unexplored:light_blue_snowbelle regions_unexplored:blue_snowbelle regions_unexplored:purple_snowbelle regions_unexplored:magenta_snowbelle regions_unexplored:pink_snowbelle regions_unexplored:brown_snowbelle regions_unexplored:black_snowbelle regions_unexplored:ashen_sapling regions_unexplored:alpha_sapling regions_unexplored:apple_oak_sapling regions_unexplored:bamboo_sapling regions_unexplored:baobab_sapling regions_unexplored:blackwood_sapling regions_unexplored:cactus_flower regions_unexplored:magnolia_sapling regions_unexplored:cypress_sapling regions_unexplored:dead_pine_sapling regions_unexplored:dead_sapling regions_unexplored:eucalyptus_sapling regions_unexplored:flowering_sapling regions_unexplored:golden_larch_sapling regions_unexplored:joshua_sapling regions_unexplored:kapok_sapling regions_unexplored:larch_sapling regions_unexplored:maple_sapling regions_unexplored:mauve_sapling regions_unexplored:orange_maple_sapling regions_unexplored:palm_sapling regions_unexplored:pine_sapling regions_unexplored:blue_magnolia_sapling regions_unexplored:pink_magnolia_sapling regions_unexplored:redwood_sapling regions_unexplored:red_maple_sapling regions_unexplored:brimwood_sapling regions_unexplored:cobalt_sapling regions_unexplored:enchanted_birch_sapling regions_unexplored:small_oak_sapling regions_unexplored:silver_birch_sapling regions_unexplored:socotra_sapling regions_unexplored:white_magnolia_sapling regions_unexplored:willow_sapling regions_unexplored:willow_shrub:half=lower regions_unexplored:spruce_shrub:half=lower regions_unexplored:socotra_shrub:half=lower regions_unexplored:enchanted_birch_shrub:half=lower regions_unexplored:silver_birch_shrub:half=lower regions_unexplored:redwood_shrub:half=lower regions_unexplored:pine_shrub:half=lower regions_unexplored:palm_shrub:half=lower regions_unexplored:oak_shrub:half=lower regions_unexplored:mauve_shrub:half=lower regions_unexplored:red_maple_shrub:half=lower regions_unexplored:orange_maple_shrub:half=lower regions_unexplored:maple_shrub:half=lower regions_unexplored:mangrove_shrub:half=lower regions_unexplored:white_magnolia_shrub:half=lower regions_unexplored:pink_magnolia_shrub:half=lower regions_unexplored:blue_magnolia_shrub:half=lower regions_unexplored:magnolia_shrub:half=lower regions_unexplored:golden_larch_shrub:half=lower regions_unexplored:larch_shrub:half=lower regions_unexplored:kapok_shrub:half=lower regions_unexplored:jungle_shrub:half=lower regions_unexplored:joshua_shrub:half=lower regions_unexplored:flowering_shrub:half=lower regions_unexplored:eucalyptus_shrub:half=lower regions_unexplored:dead_shrub:half=lower regions_unexplored:dead_pine_shrub:half=lower regions_unexplored:dark_oak_shrub:half=lower regions_unexplored:cypress_shrub:half=lower regions_unexplored:cherry_shrub:half=lower regions_unexplored:brimwood_shrub:half=lower regions_unexplored:blackwood_shrub:half=lower regions_unexplored:birch_shrub:half=lower regions_unexplored:baobab_shrub:half=lower regions_unexplored:ashen_shrub:half=lower regions_unexplored:acacia_shrub:half=lower \
+\
+ribbits:umbrella_leaf ribbits:swamp_daisy \
 \
 aether:golden_oak_sapling aether:skyroot_sapling \
 \
@@ -143,13 +165,17 @@ expandeddelight:cinnamon_sapling expandeddelight:wild_asparagus expandeddelight:
 \
 culturaldelights:wild_cucumbers culturaldelights:wild_eggplants culturaldelights:avocado_sapling \
 \
-natures_spirit:frigid_grass natures_spirit:tall_frigid_grass \
+garnished:soul_roots garnished:aureate_shrub garnished:sepia_fungus garnished:small_chorus_plant garnished:barren_roots garnished:incandescent_lily garnished:pansophical_daisy \
+\
+naturalist:cattail:half=lower \
+\
+natures_spirit:dwarf_blossoms natures_spirit:black_iris natures_spirit:blue_iris natures_spirit:protea natures_spirit:ruby_blossoms natures_spirit:desert_turnip_stem natures_spirit:purple_heather natures_spirit:red_heather natures_spirit:white_heather natures_spirit:regal_succulent natures_spirit:foamy_succulent natures_spirit:imperial_succulent natures_spirit:sage_succulent natures_spirit:drowsy_succulent natures_spirit:aureate_succulent natures_spirit:ornate_succulent natures_spirit:cattail:half=lower natures_spirit:foxglove:half=lower natures_spirit:marigold:half=lower natures_spirit:snapdragon:half=lower natures_spirit:gardenia:half=lower natures_spirit:carnation:half=lower natures_spirit:bleeding_heart:half=lower natures_spirit:lavender:half=lower natures_spirit:large_flaxen_fern:half=lower natures_spirit:tall_sedge_grass:half=lower natures_spirit:beach_grass natures_spirit:tall_beach_grass:half=lower natures_spirit:oat_grass natures_spirit:lush_fern natures_spirit:melic_grass natures_spirit:tall_oat_grass:half=lower natures_spirit:large_lush_fern:half=lower natures_spirit:tall_melic_grass:half=lower natures_spirit:green_bitter_sprouts natures_spirit:red_bitter_sprouts natures_spirit:purple_bitter_sprouts natures_spirit:green_bearberries natures_spirit:red_bearberries natures_spirit:purple_bearberries natures_spirit:blue_bulbs:half=lower natures_spirit:silverbush:half=lower natures_spirit:tall_scorched_grass:half=lower natures_spirit:tall_frigid_grass:half=lower natures_spirit:yellow_larch_sapling natures_spirit:larch_sapling natures_spirit:mahogany_sapling natures_spirit:cedar_sapling natures_spirit:saxaul_sapling natures_spirit:palo_verde_sapling natures_spirit:ghaf_sapling natures_spirit:joshua_sapling natures_spirit:olive_sapling natures_spirit:cypress_sapling natures_spirit:yellow_maple_sapling natures_spirit:orange_maple_sapling natures_spirit:red_maple_sapling natures_spirit:aspen_sapling natures_spirit:willow_sapling natures_spirit:fir_sapling natures_spirit:sugi_sapling natures_spirit:purple_wisteria_sapling natures_spirit:pink_wisteria_sapling natures_spirit:blue_wisteria_sapling natures_spirit:white_wisteria_sapling natures_spirit:redwood_sapling natures_spirit:hibiscus natures_spirit:anemone natures_spirit:yellow_wildflower natures_spirit:purple_wildflower natures_spirit:tiger_lily natures_spirit:bluebell natures_spirit:shiitake_mushroom natures_spirit:flaxen_fern natures_spirit:sedge_grass natures_spirit:scorched_grass natures_spirit:frigid_grass \
 \
 soulsweapons:withered_grass soulsweapons:withered_berry_bush soulsweapons:withered_fern soulsweapons:hydrangea \
 \
-vinery:cherry_sapling vinery:apple_tree_sapling \
+sandwichable:ancient_grain sandwichable:onions sandwichable:cucumbers sandwichable:tomatoes sandwichable:lettuce sandwichable:shrub \
 \
-regions_unexplored:sandy_grass regions_unexplored:medium_grass regions_unexplored:bladed_grass regions_unexplored:bladed_tall_grass \
+vinery:cherry_sapling vinery:apple_tree_sapling \
 \
 traverse:yellow_autumnal_sapling \
 \
@@ -181,7 +207,11 @@ aether_redux:zanberry_bush_stem aether_redux:luxweed aether_redux:spirolyctil ae
 \
 theabyss:gulom_plant theabyss:ralom_plant theabyss:fortris_ultima theabyss:srala_shroom theabyss:saturnia_versa theabyss:caecus_versa theabyss:tall_glow_shroom:half=lower theabyss:glow_shroom:half=lower theabyss:tall_rub_shroom:half=lower theabyss:rub_shroom:half=lower theabyss:exolius_plant theabyss:young_exolius_plant theabyss:vigilant_grass theabyss:vigilant_blue_grass theabyss:vigilant_outer_leaves theabyss:vigilant_blue_outer_leaves theabyss:blaru_grass theabyss:tall_blaru_grass:half=lower theabyss:slimed_grass \
 \
-the_deep_void:rotten_grass:half=lower the_deep_void:bone_marrow the_deep_void:cave_growth
+the_deep_void:rotten_grass:half=lower the_deep_void:bone_marrow the_deep_void:cave_growth \
+\
+verdantvibes:dragon_tree \
+\
+vinery:taiga_grape_bush_red vinery:red_grape_bush vinery:taiga_grape_bush_white vinery:white_grape_bush vinery:savanna_grape_bush_red vinery:savanna_grape_bush_white
 
 #else
 # Short Foliage / Foliage Lower Half - Before 1.13
@@ -202,11 +232,15 @@ betterend:lucernia_outer_leaves betterend:lucernia_leaves betterend:cave_bush be
 # Leaves
 block.10009 = leaves leaves2 oak_leaves birch_leaves dark_oak_leaves azalea_leaves \
 \
+beachparty:palm_leaves \
+\
+blossom:flowering_oak_leaves \
+\
 hydrol:oak_leaves_wall hydrol:dark_oak_leaves_wall hydrol:birch_leaves_wall hydrol:azalea_leaves_wall hydrol:oak_leaves_pile hydrol:dark_oak_leaves_pile hydrol:birch_leaves_pile hydrol:azalea_leaves_pile \
 \
 wondrouswilds:yellow_birch_leaves wondrouswilds:orange_birch_leaves wondrouswilds:red_birch_leaves \
 \
-natures_spirit:willow_leaves natures_spirit:fir_leaves \
+natures_spirit:palo_verde_leaves natures_spirit:ghaf_leaves natures_spirit:joshua_leaves natures_spirit:olive_leaves natures_spirit:cypress_leaves natures_spirit:yellow_maple_leaves natures_spirit:orange_maple_leaves natures_spirit:red_maple_leaves natures_spirit:aspen_leaves natures_spirit:willow_leaves natures_spirit:frosty_fir_leaves natures_spirit:fir_leaves natures_spirit:coconut_leaves natures_spirit:cedar_leaves natures_spirit:larch_leaves natures_spirit:yellow_larch_leaves natures_spirit:mahogany_leaves natures_spirit:saxaul_leaves natures_spirit:wisteria_leaves natures_spirit:part_purple_wisteria_leaves natures_spirit:part_pink_wisteria_leaves natures_spirit:part_blue_wisteria_leaves natures_spirit:part_white_wisteria_leaves natures_spirit:purple_wisteria_leaves natures_spirit:pink_wisteria_leaves natures_spirit:blue_wisteria_leaves natures_spirit:white_wisteria_leaves natures_spirit:sugi_leaves natures_spirit:redwood_leaves \
 \
 terrestria:redwood_leaves terrestria:hemlock_leaves terrestria:rubber_leaves terrestria:cypress_leaves terrestria:willow_leaves terrestria:japanese_maple_leaves terrestria:rainbow_eucalyptus_leaves terrestria:sakura_leaves terrestria:yuca_palm_leaves terrestria:japanese_maple_shrub_leaves terrestria:dark_japanese_maple_leaves terrestria:jungle_palm_leaves terrestria:yucca_palm_leaves \
 \
@@ -216,9 +250,13 @@ biomemakeover:belighted_balsa_leaves biomemakeover:willow_leaves biomemakeover:a
 \
 vinery:apple_leaves vinery:grapevine_leaves vinery:cherry_leaves \
 \
+meadow:pine_leaves meadow:alpine_birch_leaves_hanging \
+\
 ecologics:coconut_leaves ecologics:walnut_leaves \
 \
 goodending:cypress_leaves \
+\
+garnished:chestnut_leaves garnished:hazelnut_leaves garnished:pecan_leaves garnished:almond_leaves garnished:pistachio_leaves garnished:macadamia_leaves garnished:cashew_leaves garnished:walnut_leaves garnished:peanut_leaves garnished:nut_leaves \
 \
 quark:ancient_leaves quark:blue_blossom_leaves quark:lavender_blossom_leaves quark:orange_blossom_leaves quark:pink_blossom_leaves quark:yellow_blossom_leaves quark:red_blossom_leaves \
 \
@@ -273,16 +311,24 @@ biomemakeover:willowing_branches \
 \
 blue_skies:bluebright_vine blue_skies:starlit_vine blue_skies:frostbright_vine blue_skies:lunar_vine blue_skies:dusk_vine blue_skies:maple_vine \
 \
+natures_spirit:willow_vines natures_spirit:willow_vines_plant natures_spirit:white_wisteria_vines natures_spirit:white_wisteria_vines_plant natures_spirit:blue_wisteria_vines natures_spirit:blue_wisteria_vines_plant natures_spirit:pink_wisteria_vines natures_spirit:pink_wisteria_vines_plant natures_spirit:purple_wisteria_vines natures_spirit:purple_wisteria_vines_plant \
+\
+regions_unexplored:spanish_moss regions_unexplored:spanish_moss_plant regions_unexplored:kapok_vines regions_unexplored:kapok_vines_plant \
+\
 undergarden:hanging_grongle_leaves \
 \
 deep_aether:sunroot_hanger \
 \
 aether_redux:golden_vines aether_redux:gilded_vines \
 \
-twilightforest:root_strand twilightforest:trollvidr twilightforest:unripe_trollber twilightforest:trollber deep_aether:yagroot_vine
+twilightforest:root_strand twilightforest:trollvidr twilightforest:unripe_trollber twilightforest:trollber deep_aether:yagroot_vine \
+\
+vinery:jungle_grape_bush_white vinery:jungle_grape_bush_red
 
 # Non-Waving Foliage - Euphoria Patches Interactive Foliage
-block.10015 = seagrass tall_seagrass kelp_plant kelp
+block.10015 = seagrass tall_seagrass kelp_plant kelp \
+\
+garnished:vermilion_kelp garnished:dulse_kelp garnished:vermilion_kelp_plant garnished:dulse_kelp_plant
 
 # Non-Waving Foliage
 block.10017 = reeds attached_pumpkin_stem attached_melon_stem hanging_roots spore_blossom cobweb mangrove_propagule \
@@ -303,13 +349,23 @@ block.10019 = pink_petals pitcher_plant
 # Tall Foliage Upper Half
 block.10021 = double_plant:half=upper tall_grass:half=upper large_fern:half=upper \
 \
+brewery:hops_crop brewery:wild_hops:half=upper \
+\
 farmersdelight:wild_rice:half=upper farmersdelight:rice_panicles \
 \
 supplementaries:flax:half=upper \
 \
 festive_delight:cinnamon_bushripe:half=upper \
 \
+hauntedharvest:corn_middle hauntedharvest:corn_top \
+\
 hydrol:dry_grass:half=top \
+\
+meadow:eriophorum_tall:half=upper meadow:small_fir:half=upper \
+\
+naturalist:cattail:half=upper \
+\
+natures_spirit:cattail:half=upper natures_spirit:foxglove:half=upper natures_spirit:marigold:half=upper natures_spirit:lotus_flower natures_spirit:lotus_stem natures_spirit:snapdragon:half=upper natures_spirit:gardenia:half=upper natures_spirit:carnation:half=upper natures_spirit:bleeding_heart:half=upper natures_spirit:lavender:half=upper natures_spirit:large_flaxen_fern:half=upper natures_spirit:tall_sedge_grass:half=upper natures_spirit:tall_oat_grass:half=upper natures_spirit:large_lush_fern:half=upper natures_spirit:tall_melic_grass:half=upper natures_spirit:tall_beach_grass:half=upper natures_spirit:blue_bulbs:half=upper natures_spirit:silverbush:half=upper natures_spirit:tall_scorched_grass:half=upper natures_spirit:tall_frigid_grass:half=upper \
 \
 biomesoplenty:barley:half=upper biomesoplenty:cattail:half=upper biomesoplenty:sea_oats:half=upper biomesoplenty:watergrass:half=upper biomesoplenty:reed:half=upper \
 \
@@ -317,7 +373,7 @@ biomemakeover:black_thistle:half=upper biomemakeover:foxglove:half=upper biomema
 \
 soulsweapons:withered_tall_grass:half=upper soulsweapons:withered_large_fern:half=upper soulsweapons:oleander:half=upper \
 \
-regions_unexplored:dusktrap:half=upper regions_unexplored:windswept_grass:half=upper regions_unexplored:steppe_tall_grass:half=upper regions_unexplored:sandy_tall_grass:half=upper regions_unexplored:corpse_flower:half=upper regions_unexplored:joshua_leaves:half=upper regions_unexplored:tall_cobalt_earlight:half=upper regions_unexplored:mycotoxic_daisy:half=upper regions_unexplored:glister_spire:half=upper regions_unexplored:glister_bulb:half=upper regions_unexplored:meadow_sage:half=upper regions_unexploredday_lily:half=upper terrestria:cattail regions_unexplored:cattail:half=upper regions_unexplored:barley:half=upper regions_unexplored:tall_blue_bioshroom:half=upper regions_unexplored:tall_yellow_bioshroom:half=upper regions_unexplored:tall_pink_bioshroom:half=upper regions_unexplored:tall_green_bioshroom:half=upper \
+regions_unexplored:bladed_tall_grass:half=upper regions_unexplored:tassel:half=upper regions_unexplored:dusktrap:half=upper regions_unexplored:windswept_grass:half=upper regions_unexplored:steppe_tall_grass:half=upper regions_unexplored:sandy_tall_grass:half=upper regions_unexplored:corpse_flower:half=upper regions_unexplored:joshua_leaves:half=upper regions_unexplored:tall_cobalt_earlight:half=upper regions_unexplored:mycotoxic_daisy:half=upper regions_unexplored:glister_spire:half=upper regions_unexplored:glister_bulb:half=upper regions_unexplored:meadow_sage:half=upper regions_unexplored:day_lily:half=upper terrestria:cattail regions_unexplored:cattail:half=upper regions_unexplored:barley:half=upper regions_unexplored:tall_blue_bioshroom:half=upper regions_unexplored:tall_yellow_bioshroom:half=upper regions_unexplored:tall_pink_bioshroom:half=upper regions_unexplored:tall_green_bioshroom:half=upper regions_unexplored:willow_shrub:half=upper regions_unexplored:spruce_shrub:half=upper regions_unexplored:socotra_shrub:half=upper regions_unexplored:enchanted_birch_shrub:half=upper regions_unexplored:silver_birch_shrub:half=upper regions_unexplored:redwood_shrub:half=upper regions_unexplored:pine_shrub:half=upper regions_unexplored:palm_shrub:half=upper regions_unexplored:oak_shrub:half=upper regions_unexplored:mauve_shrub:half=upper regions_unexplored:red_maple_shrub:half=upper regions_unexplored:orange_maple_shrub:half=upper regions_unexplored:maple_shrub:half=upper regions_unexplored:mangrove_shrub:half=upper regions_unexplored:white_magnolia_shrub:half=upper regions_unexplored:pink_magnolia_shrub:half=upper regions_unexplored:blue_magnolia_shrub:half=upper regions_unexplored:magnolia_shrub:half=upper regions_unexplored:golden_larch_shrub:half=upper regions_unexplored:larch_shrub:half=upper regions_unexplored:kapok_shrub:half=upper regions_unexplored:jungle_shrub:half=upper regions_unexplored:joshua_shrub:half=upper regions_unexplored:flowering_shrub:half=upper regions_unexplored:eucalyptus_shrub:half=upper regions_unexplored:dead_shrub:half=upper regions_unexplored:dead_pine_shrub:half=upper regions_unexplored:dark_oak_shrub:half=upper regions_unexplored:cypress_shrub:half=upper regions_unexplored:cherry_shrub:half=upper regions_unexplored:brimwood_shrub:half=upper regions_unexplored:blackwood_shrub:half=upper regions_unexplored:birch_shrub:half=upper regions_unexplored:baobab_shrub:half=upper regions_unexplored:ashen_shrub:half=upper regions_unexplored:acacia_shrub:half=upper \
 \
 blue_skies:tall_turquoise_grass:half=upper blue_skies:snowcap_mushroom:half=upper blue_skies:tall_lunar_grass:half=upper \
 \
@@ -492,7 +548,9 @@ block.10083 = stone_pressure_plate:powered=true stone_button:powered=true
 block.10084 = granite
 
 # Granite Non-Full Blocks - 1.13+
-block.10085 = granite_wall granite_slab granite_stairs
+block.10085 = granite_wall granite_slab granite_stairs \
+\
+enchanted-vertical-slabs:vertical_polished_granite_slab
 
 # Diorite Full Block - 1.13+
 block.10088 = diorite
@@ -520,14 +578,18 @@ block.10100 = polished_diorite
 # Polished Diorite Non-Full Blocks - 1.13+
 block.10101 = polished_diorite_stairs polished_diorite_slab \
 \
-betterend:diorite_pedestal
+betterend:diorite_pedestal \
+\
+enchanted-vertical-slabs:vertical_polished_diorite_slab
 
 # Polished Andesite Full Block / Mud Brick Full Block - 1.13+
 block.10104 = polished_andesite packed_mud mud_bricks bricks \
 \
 betternether:soul_sandstone betternether:soul_sandstone_smooth betternether:soul_sandstone_chiseled betternether:soul_sandstone_cut \
 \
-betterend:azure_jadestone_furnace:lit=false betterend:azure_jadestone betterend:azure_jadestone_bricks betterend:azure_jadestone_polished betterend:azure_jadestone_tiles betterend:azure_jadestone_pillar
+betterend:azure_jadestone_furnace:lit=false betterend:azure_jadestone betterend:azure_jadestone_bricks betterend:azure_jadestone_polished betterend:azure_jadestone_tiles betterend:azure_jadestone_pillar \
+\
+enchanted-vertical-slabs:vertical_brick_slab
 
 # Polished Andesite Non-Full Blocks / Mud Brick Non-Full Blocks - 1.13+
 block.10105 = mud_brick_wall brick_wall polished_andesite_stairs polished_andesite_slab mud_brick_stairs mud_brick_slab brick_slab brick_stairs \
@@ -622,20 +684,26 @@ block.10137 = farmland:moisture=7
 
 block.10140 = netherrack \
 \
-betternether:netherrack_moss betternether:netherrack_furnace:lit=false
+betternether:netherrack_moss betternether:netherrack_furnace:lit=false \
+\
+scorchful:rooted_netherrack
 
 block.10144 = warped_nylium \
 \
 betternether:mushroom_grass betternether:sepia_mushroom_grass betternether:jungle_grass betternether:nether_mycelium:blue=true \
 \
-betterend:rutiscus betterend:sangnum betterend:cave_moss 
+betterend:rutiscus betterend:sangnum betterend:cave_moss \
+\
+scorchful:rooted_warped_nylium
 
 # Warped Wart Block - Euphoria Patched Emissive Wart Blocks
 block.10146 = warped_wart_block
 
 block.10148 = crimson_nylium \
 \
-betternether:ceiling_mushrooms betternether:swampland_grass
+betternether:ceiling_mushrooms betternether:swampland_grass \
+\
+scorchful:rooted_crimson_nylium
 
 # Nether Wart Block - Euphoria Patched Emissive Wart Blocks
 block.10150 = nether_wart_block \
@@ -868,15 +936,25 @@ block.10228 = bedrock
 #if MC_VERSION >= 11300
 block.10232 = sand suspicious_sand \
 \
-betterend:endstone_dust
+beachparty:sandwaves \
+\
+betterend:endstone_dust \
+\
+more_slabs_stairs_and_walls:sand_slab \
+\
+scorchful:sand_piles
 
-block.10236 = red_sand
+block.10236 = red_sand \
+\
+scorchful:red_sand_piles
 
 # Sandstone Full Block
 block.10240 = sandstone chiseled_sandstone cut_sandstone smooth_sandstone
 
 # Sandstone Non-Full Block
-block.10241 = sandstone_wall sandstone_slab cut_sandstone_slab sandstone_stairs smooth_sandstone_stairs smooth_sandstone_slab
+block.10241 = sandstone_wall sandstone_slab cut_sandstone_slab sandstone_stairs smooth_sandstone_stairs smooth_sandstone_slab \
+\
+enchanted-vertical-slabs:vertical_sandstone_slab enchanted-vertical-slabs:vertical_smooth_sandstone_slab enchanted-vertical-slabs:vertical_cut_sandstone_slab
 #else
 block.10232 = sand:variant=sand
 
@@ -1173,6 +1251,10 @@ block.10365 = quartz_slab quartz_stairs smooth_quartz_stairs smooth_quartz_slab 
 \
 betterend:quartz_pedestal \
 \
+more_slabs_stairs_and_walls:quartz_bricks_slab more_slabs_stairs_and_walls:quartz_bricks_stairs more_slabs_stairs_and_walls:quartz_bricks_wall more_slabs_stairs_and_walls:smooth_quartz_wall more_slabs_stairs_and_walls:quartz_block_wall \
+\
+enchanted-vertical-slabs:vertical_quartz_slab enchanted-vertical-slabs:vertical_smooth_quartz_slab \
+\
 supplementaries:checker_slab supplementaries:checker_vertical_slab
 #else
 # Non-Full Quartz Block Before 1.13
@@ -1216,18 +1298,28 @@ block.10380 = snow_block \
 \
 betterend:dense_snow \
 \
+frostiful:packed_snow_block frostiful:packed_snow_bricks \
+\
 supplementaries:sugar_cube
 
 # Non-Full Snow Blocks
-block.10381 = snow_layer snow powder_snow
+block.10381 = snow_layer snow powder_snow \
+\
+frostiful:packed_snow frostiful:packed_snow_brick_stairs frostiful:packed_snow_brick_slab frostiful:packed_snow_brick_wall
 
 block.10384 = packed_ice \
 \
-betterend:dense_emerald_ice
+betterend:dense_emerald_ice \
+\
+frostiful:ice_pane frostiful:cut_packed_ice frostiful:cut_packed_ice_stairs frostiful:cut_packed_ice_slab frostiful:cut_packed_ice_wall
 
 block.10388 = blue_ice \
 \
-betterend:ancient_emerald_ice
+betterend:ancient_emerald_ice \
+\
+frostiful:icicle frostiful:cut_blue_ice frostiful:cut_blue_ice_stairs frostiful:cut_blue_ice_slab frostiful:cut_blue_ice_wall \
+\
+regions_unexplored:icicle
 
 block.10392 = pumpkin carved_pumpkin \
 \
@@ -1276,7 +1368,9 @@ block.10417 = nether_brick_fence stone_slab:variant=nether_brick nether_brick_st
 block.10420 = red_nether_bricks
 
 # Red Nether Bricks Non-Full Blocks
-block.10421 = red_nether_brick_wall red_nether_brick_slab red_nether_brick_stairs
+block.10421 = red_nether_brick_wall red_nether_brick_slab red_nether_brick_stairs \
+\
+enchanted-vertical-slabs:vertical_red_nether_brick_slab
 
 block.10424 = melon_block melon
 
@@ -1403,7 +1497,15 @@ block.10484 = gilded_blackstone
 
 block.10489 = waterlily lily_pad frogspawn \
 \
-betterend:flamaea
+betterend:flamaea \
+\
+naturalist:duckweed \
+\
+natures_spirit:helvola \
+\
+regions_unexplored:duckweed regions_unexplored:flowering_lily_pad \
+\
+ribbits:giant_lilypad
 
 block.10493 = dirt_path grass_path
 
@@ -1442,7 +1544,7 @@ block.10521 = cactus \
 \
 betternether:barrel_cactus betternether:nether_cactus \
 \
-regions_unexplored:barrel_cactus
+regions_unexplored:barrel_cactus regions_unexplored:saguaro_cactus
 
 # Unpowered Noteblock
 block.10524 = noteblock:powered=false note_block:powered=false jukebox \


### PR DESCRIPTION
This is my first pull request so my bad if the etiquette isn't up to snuff. I've been using and adding on to many of these since Comp 5.1 released so I figured I'd add any new things I have to the current file, along with some small fixes for entries that seem outdated or broken.

Everything was checked by painstakingly placing each piece of foliage from every mod listed here, so hopefully I didn't make any mistakes or forget something along the way. All changes were based on the latest version of each mod on Fabric, for the record.


Added entries/fixed missing foliage from:

Blossom
Create: Garnished
Create: Bitterballen
[Let's Do] Bakery
[Let's Do] Brewery
[Let's Do] Candlelight
[Let's Do] HerbalBrews
[Let's Do] Vinery/NetherVinery
[Let's Do] Beachparty
[Let's Do] Meadow
Nature's Spirit
Farmer's Delight (the sandy shrub didn't have an entry, that's all, lol)
Galosphere
Ribbits
Scorchful
Frostiful
Snowy Spirit
Naturalist
Galosphere
Verdant Vibes
Haunted Harvest
Sandwichable
Regions Unexplored (Fixed all shrub blocks being incorrectly set as 1-block high foliage instead of 2. Also added/fixed many other missing entries, such as lilypads).

Also added some select blocks from Enchanted Vertical Slabs and More Slabs, Stairs, and Walls, but nothing significant.


