### PR TITLE
Update block.properties with mod support

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -399,6 +399,10 @@ block.10024 = betternether:nether_ruby_ore \
 \
 betterend:amber_ore \
 \
+create:zinc_ore create:deepslate_zinc_ore \
+\
+cobblemon:shiny_stone_ore cobblemon:deepslate_shiny_stone_ore \
+\
 mythicmetals:deepslate_prometheum_ore mythicmetals:stormyx_ore mythicmetals:blackstone_stormyx_ore mythicmetals:unobtainium_ore mythicmetals:deepslaate_unobtainium_ore mythicmetals:calcite_starrite_ore mythicmetals:end_stone_starrite_ore \
 \
 galosphere:silver_ore galosphere:deepslate_silver_ore \
@@ -471,6 +475,8 @@ block.10041 = golden_rail powered_rail detector_rail rail activator_rail
 #if MC_VERSION >= 11300
 # Cauldron / Unlocked Hopper - 1.13+
 block.10045 = cauldron hopper:enabled=true \
+\
+create:basin create:chute \
 \
 supplementaries:faucet supplementaries:cage
 
@@ -587,6 +593,10 @@ betternether:soul_sandstone betternether:soul_sandstone_smooth betternether:soul
 \
 betterend:azure_jadestone_furnace:lit=false betterend:azure_jadestone betterend:azure_jadestone_bricks betterend:azure_jadestone_polished betterend:azure_jadestone_tiles betterend:azure_jadestone_pillar \
 \
+create:andesite_casing create:cut_andesite create:polished_cut_andesite create:cut_andesite_bricks create:small_andesite_bricks create:layered_andesite create:andesite_pillar \
+\
+quark:andesite_bricks quark:chiseled_andesite_bricks quark:andesite_pillar \
+\
 enchanted-vertical-slabs:vertical_brick_slab
 
 # Polished Andesite Non-Full Blocks / Mud Brick Non-Full Blocks - 1.13+
@@ -594,7 +604,11 @@ block.10105 = mud_brick_wall brick_wall polished_andesite_stairs polished_andesi
 \
 betternether:soul_sandstone_smooth_stairs betternether:soul_sandstone_stairs betternether:soul_sandstone_cut_stairs betternether:soul_sandstone_smooth_slab betternether:soul_sandstone_slab betternether:soul_sandstone_cut_slab betternether:soul_sandstone_wall betternether:netherrack_stalactite \
 \
-betterend:andesite_pedestal betterend:azure_jadestone_stairs betterend:azure_jadestone_slab betterend:azure_jadestone_wall betterend:azure_jadestone_button betterend:azure_jadestone_plate betterend:azure_jadestone_pedestal betterend:azure_jadestone_bricks_stairs betterend:azure_jadestone_bricks_slab betterend:azure_jadestone_bricks_wall
+betterend:andesite_pedestal betterend:azure_jadestone_stairs betterend:azure_jadestone_slab betterend:azure_jadestone_wall betterend:azure_jadestone_button betterend:azure_jadestone_plate betterend:azure_jadestone_pedestal betterend:azure_jadestone_bricks_stairs betterend:azure_jadestone_bricks_slab betterend:azure_jadestone_bricks_wall \
+\
+create:andesite_ladder create:andesite_bars create:andesite_scaffolding create:andesite_funnel create:andesite_tunnel create:cut_andesite_stairs create:cut_andesite_slab create:cut_andesite_wall create:polished_cut_andesite_stairs create:polished_cut_andesite_slab create:polished_cut_andesite_wall create:cut_andesite_brick_stairs create:cut_andesite_brick_slab create:cut_andesite_brick_wall create:small_andesite_brick_stairs create:small_andesite_brick_slab create:small_andesite_brick_wall \
+\
+quark:andesite_bricks_stairs quark:andesite_bricks_slab quark:andesite_bricks_wall
 
 #else
 # The following are before 1.13 variants
@@ -630,7 +644,13 @@ block.10112 = polished_deepslate deepslate_bricks cracked_deepslate_bricks deeps
 # Other Deepslate - Non-Full Blocks / Mangrove Non-Full Blocks
 block.10113 = polished_deepslate_wall deepslate_brick_wall deepslate_tile_wall polished_deepslate_stairs deepslate_brick_stairs deepslate_tile_stairs polished_deepslate_slab deepslate_brick_slab deepslate_tile_slab mangrove_roots
 
-block.10116 = calcite
+block.10116 = calcite \
+\
+create:cut_calcite create:cut_calcite_stairs create:cut_calcite_slab create:cut_calcite_wall create:polished_cut_calcite create:polished_cut_calcite_slab create:polished_cut_calcite_stairs create:polished_cut_calcite_wall create:cut_calcite_bricks create:cut_calcite_bricks create:cut_calcite_brick_slab create:cut_calcite_brick_wall create:cut_calcite_brick_stairs create:small_calcite_bricks create:small_calcite_brick_slab create:small_calcite_brick_stairs create:small_calcite_brick_wall create:layered_calcite create:calcite_pillar \
+\
+handcrafted:calcite_pillar_trim handcrafted:calcite_corner_trim \
+\
+quark:calcite_wall quark:calcite_slab quark:calcite_stairs quark:polished_calcite quark:calcite_bricks quark:chiseled_calcite_bricks quark:calcite_pillar quark:calcite_bricks_wall quark:calcite_bricks_stairs quark:calcite_bricks_slab quark:polished_calcite_slab quark:polished_calcite_stairs
 
 block.10120 = dripstone_block
 
@@ -748,6 +768,8 @@ hydrol:oak_wood_wall \
 \
 betternether:oak_taburet betternether:oak_bar_stool betternether:oak_chair \
 \
+create:oak_window create:oak_window_pane \
+\
 amendments:tool_hook \
 \
 supplementaries:item_shelf
@@ -771,7 +793,9 @@ hydrol:spruce_wood_wall \
 \
 betternether:spruce_taburet betternether:spruce_bar_stool betternether:spruce_chair \
 \
-betterend:umbrella_tree_composter betterend:umbrella_tree_chest betterend:umbrella_tree_stairs betterend:umbrella_tree_slab betterend:umbrella_tree_fence betterend:umbrella_tree_gate betterend:umbrella_tree_button betterend:umbrella_tree_plate betterend:umbrella_tree_trapdoor betterend:umbrella_tree_door betterend:umbrella_tree_ladder betterend:umbrella_tree_taburet betterend:umbrella_tree_bar_stool betterend:umbrella_tree_chair betterend:umbrella_tree_wall 
+betterend:umbrella_tree_composter betterend:umbrella_tree_chest betterend:umbrella_tree_stairs betterend:umbrella_tree_slab betterend:umbrella_tree_fence betterend:umbrella_tree_gate betterend:umbrella_tree_button betterend:umbrella_tree_plate betterend:umbrella_tree_trapdoor betterend:umbrella_tree_door betterend:umbrella_tree_ladder betterend:umbrella_tree_taburet betterend:umbrella_tree_bar_stool betterend:umbrella_tree_chair betterend:umbrella_tree_wall \
+\
+create:spruce_window create:spruce_window_pane
 
 # Spruce Powered Blocks - Euphoria Patches Redstone IPBR
 block.10167 = spruce_fence_gate:powered=true spruce_button:powered=true spruce_pressure_plate:powered=true
@@ -790,7 +814,9 @@ hydrol:birch_wood_wall \
 \
 betternether:birch_taburet betternether:birch_bar_stool betternether:birch_chair \
 \
-betterend:end_lotus_composter betterend:end_lotus_chest betterend:end_lotus_stairs betterend:end_lotus_slab betterend:end_lotus_fence betterend:end_lotus_gate betterend:end_lotus_button betterend:end_lotus_plate betterend:end_lotus_trapdoor betterend:end_lotus_door betterend:end_lotus_ladder betterend:end_lotus_taburet betterend:end_lotus_bar_stool betterend:end_lotus_chair betterend:end_lotus_wall
+betterend:end_lotus_composter betterend:end_lotus_chest betterend:end_lotus_stairs betterend:end_lotus_slab betterend:end_lotus_fence betterend:end_lotus_gate betterend:end_lotus_button betterend:end_lotus_plate betterend:end_lotus_trapdoor betterend:end_lotus_door betterend:end_lotus_ladder betterend:end_lotus_taburet betterend:end_lotus_bar_stool betterend:end_lotus_chair betterend:end_lotus_wall \
+\
+create:birch_window create:birch_window_pane
 
 # Birch Powered Blocks - Euphoria Patches Redstone IPBR
 block.10175 = birch_fence_gate:powered=true birch_button:powered=true birch_pressure_plate:powered=true
@@ -809,17 +835,23 @@ block.10181 = jungle_fence jungle_fence_gate:powered=false jungle_button:powered
 \
 hydrol:jungle_wood_wall \
 \
-betternether:jungle_taburet betternether:jungle_bar_stool betternether:jungle_chair
+betternether:jungle_taburet betternether:jungle_bar_stool betternether:jungle_chair \
+\
+create:jungle_window create:jungle_window_pane
 
 # Jungle Powered Blocks - Euphoria Patches Redstone IPBR
 block.10183 = jungle_fence_gate:powered=true jungle_button:powered=true jungle_pressure_plate:powered=true
 
-block.10184 = log:variant=jungle jungle_log jungle_wood
+block.10184 = log:variant=jungle jungle_log jungle_wood \
+\
+cobblemon:apricorn_log cobblemon:apricorn_wood
 
 # Acacia Full Blocks
 block.10188 = planks:variant=acacia acacia_planks stripped_acacia_log stripped_acacia_wood \
 \
-betterend:helix_tree_stripped_log betterend:helix_tree_stripped_bark betterend:helix_tree_planks betterend:helix_tree_barrel betterend:helix_tree_crafting_table betterend:helix_tree_bookshelf betterend:lucernia_stripped_log betterend:lucernia_stripped_bark betterend:lucernia_planks betterend:lucernia_barrel betterend:lucernia_crafting_table betterend:lucernia_bookshelf 
+betterend:helix_tree_stripped_log betterend:helix_tree_stripped_bark betterend:helix_tree_planks betterend:helix_tree_barrel betterend:helix_tree_crafting_table betterend:helix_tree_bookshelf betterend:lucernia_stripped_log betterend:lucernia_stripped_bark betterend:lucernia_planks betterend:lucernia_barrel betterend:lucernia_crafting_table betterend:lucernia_bookshelf \
+\
+cobblemon:apricorn_planks cobblemon:stripped_apricorn_log cobblemon:stripped_apricorn_wood
 
 # Acacia Non-Full Blocks
 block.10189 = acacia_fence acacia_fence_gate:powered=false acacia_button:powered=false acacia_pressure_plate:powered=false wooden_slab:variant=acacia acacia_slab acacia_stairs \
@@ -828,7 +860,11 @@ hydrol:acacia_wood_wall \
 \
 betternether:acacia_taburet betternether:acacia_bar_stool betternether:acacia_chair \
 \
-betterend:helix_tree_composter betterend:helix_tree_chest betterend:helix_tree_stairs betterend:helix_tree_slab betterend:helix_tree_fence betterend:helix_tree_gate betterend:helix_tree_button betterend:helix_tree_plate betterend:helix_tree_trapdoor betterend:helix_tree_door betterend:helix_tree_ladder betterend:helix_tree_taburet betterend:helix_tree_bar_stool betterend:helix_tree_chair betterend:helix_tree_wall betterend:lucernia_composter betterend:lucernia_chest betterend:lucernia_stairs betterend:lucernia_slab betterend:lucernia_fence betterend:lucernia_gate betterend:lucernia_button betterend:lucernia_plate betterend:lucernia_trapdoor betterend:lucernia_door betterend:lucernia_ladder betterend:lucernia_taburet betterend:lucernia_bar_stool betterend:lucernia_chair betterend:lucernia_wall
+betterend:helix_tree_composter betterend:helix_tree_chest betterend:helix_tree_stairs betterend:helix_tree_slab betterend:helix_tree_fence betterend:helix_tree_gate betterend:helix_tree_button betterend:helix_tree_plate betterend:helix_tree_trapdoor betterend:helix_tree_door betterend:helix_tree_ladder betterend:helix_tree_taburet betterend:helix_tree_bar_stool betterend:helix_tree_chair betterend:helix_tree_wall betterend:lucernia_composter betterend:lucernia_chest betterend:lucernia_stairs betterend:lucernia_slab betterend:lucernia_fence betterend:lucernia_gate betterend:lucernia_button betterend:lucernia_plate betterend:lucernia_trapdoor betterend:lucernia_door betterend:lucernia_ladder betterend:lucernia_taburet betterend:lucernia_bar_stool betterend:lucernia_chair betterend:lucernia_wall \
+\
+create:acacia_window create:acacia_window_pane \
+\
+cobblemon:apricorn_slab cobblemon:apricorn_stairs cobblemon:apricorn_fence cobblemon:apricorn_fence_gate cobblemon:apricorn_door cobblemon:apricorn_trapdoor cobblemon:apricorn_button cobblemon:apricorn_pressure_plate cobblemon:apricorn_sign cobblemon:apricorn_hanging_sign supplementaries:cobblemon/sign_post_apricorn
 
 # Acacia Powered Blocks - Euphoria Patches Redstone IPBR
 block.10191 = acacia_fence_gate:powered=true acacia_button:powered=true acacia_pressure_plate:powered=true
@@ -853,7 +889,9 @@ betternether:dark_oak_taburet betternether:dark_oak_bar_stool betternether:dark_
 \
 betterend:dragon_tree_composter betterend:dragon_tree_chest betterend:dragon_tree_stairs betterend:dragon_tree_slab betterend:dragon_tree_fence betterend:dragon_tree_gate betterend:dragon_tree_button betterend:dragon_tree_plate betterend:dragon_tree_trapdoor betterend:dragon_tree_door betterend:dragon_tree_ladder betterend:dragon_tree_taburet betterend:dragon_tree_bar_stool betterend:dragon_tree_chair betterend:dragon_tree_wall \
 \
-supplementaries:timber_frame supplementaries:timber_brace supplementaries:timber_cross_brace supplementaries:edelwood_stick supplementaries:stick supplementaries:clock_block supplementaries:pulley_block supplementaries:rope supplementaries:rope_knot
+supplementaries:timber_frame supplementaries:timber_brace supplementaries:timber_cross_brace supplementaries:edelwood_stick supplementaries:stick supplementaries:clock_block supplementaries:pulley_block supplementaries:rope supplementaries:rope_knot \
+\
+create:dark_oak_window create:dark_oak_window_pane
 
 # Dark Oak Powered Blocks - Euphoria Patches Redstone IPBR
 block.10199 = dark_oak_fence_gate:powered=true dark_oak_button:powered=true dark_oak_pressure_plate:powered=true
@@ -872,7 +910,9 @@ block.10205 = mangrove_fence mangrove_fence_gate:powered=false mangrove_button:p
 \
 hydrol:mangrove_wood_wall \
 \
-betternether:mangrove_taburet betternether:mangrove_bar_stool betternether:mangrove_chair betternether:willow_chest betternether:willow_composter betternether:willow_fence betternether:willow_gate betternether:willow_wall betternether:willow_ladder betternether:willow_plate betternether:willow_button betternether:willow_bar_stool betternether:willow_slab betternether:willow_stairs betternether:willow_roof_stairs betternether:willow_roof_slab betternether:willow_trapdoor betternether:willow_door betternether:willow_chair betternether:willow_taburet betternether:wart_chest betternether:wart_composter betternether:wart_fence betternether:wart_gate betternether:wart_wall betternether:wart_ladder betternether:wart_plate betternether:wart_button betternether:wart_bar_stool betternether:wart_slab betternether:wart_stairs betternether:wart_roof_stairs betternether:wart_roof_slab betternether:wart_trapdoor betternether:wart_door betternether:wart_chair betternether:wart_taburet betternether:nether_sakura_chest betternether:nether_sakura_composter betternether:nether_sakura_fence betternether:nether_sakura_gate betternether:nether_sakura_wall betternether:nether_sakura_ladder betternether:nether_sakura_plate betternether:nether_sakura_button betternether:nether_sakura_bar_stool betternether:nether_sakura_slab betternether:nether_sakura_stairs betternether:nether_sakura_trapdoor betternether:nether_sakura_door betternether:nether_sakura_chair betternether:nether_sakura_taburet
+betternether:mangrove_taburet betternether:mangrove_bar_stool betternether:mangrove_chair betternether:willow_chest betternether:willow_composter betternether:willow_fence betternether:willow_gate betternether:willow_wall betternether:willow_ladder betternether:willow_plate betternether:willow_button betternether:willow_bar_stool betternether:willow_slab betternether:willow_stairs betternether:willow_roof_stairs betternether:willow_roof_slab betternether:willow_trapdoor betternether:willow_door betternether:willow_chair betternether:willow_taburet betternether:wart_chest betternether:wart_composter betternether:wart_fence betternether:wart_gate betternether:wart_wall betternether:wart_ladder betternether:wart_plate betternether:wart_button betternether:wart_bar_stool betternether:wart_slab betternether:wart_stairs betternether:wart_roof_stairs betternether:wart_roof_slab betternether:wart_trapdoor betternether:wart_door betternether:wart_chair betternether:wart_taburet betternether:nether_sakura_chest betternether:nether_sakura_composter betternether:nether_sakura_fence betternether:nether_sakura_gate betternether:nether_sakura_wall betternether:nether_sakura_ladder betternether:nether_sakura_plate betternether:nether_sakura_button betternether:nether_sakura_bar_stool betternether:nether_sakura_slab betternether:nether_sakura_stairs betternether:nether_sakura_trapdoor betternether:nether_sakura_door betternether:nether_sakura_chair betternether:nether_sakura_taburet \
+\
+create:mangrove_window create:mangrove_window_pane
 
 # Mangrove Powered Blocks - Euphoria Patches Redstone IPBR
 block.10207 = mangrove_fence_gate:powered=true mangrove_button:powered=true mangrove_pressure_plate:powered=true
@@ -893,7 +933,9 @@ block.10213 = crimson_fence crimson_fence_gate:powered=false crimson_button:powe
 \
 betternether:crimson_ladder betternether:crimson_taburet betternether:crimson_bar_stool betternether:crimson_chair betternether:crimson_composter betternether:crimson_chest betternether:rubeus_chest betternether:rubeus_composter betternether:rubeus_fence betternether:rubeus_gate betternether:rubeus_wall betternether:rubeus_ladder betternether:rubeus_plate betternether:rubeus_button betternether:rubeus_bar_stool betternether:rubeus_slab betternether:rubeus_stairs betternether:rubeus_trapdoor betternether:rubeus_door betternether:rubeus_chair betternether:rubeus_taburet \
 \
-betterend:tenanea_composter betterend:tenanea_chest betterend:tenanea_stairs betterend:tenanea_slab betterend:tenanea_fence betterend:tenanea_gate betterend:tenanea_button betterend:tenanea_plate betterend:tenanea_trapdoor betterend:tenanea_door betterend:tenanea_ladder betterend:tenanea_taburet betterend:tenanea_bar_stool betterend:tenanea_chair betterend:tenanea_wall betterend:pythadendron_composter betterend:pythadendron_chest betterend:pythadendron_stairs betterend:pythadendron_slab betterend:pythadendron_fence betterend:pythadendron_gate betterend:pythadendron_button betterend:pythadendron_plate betterend:pythadendron_trapdoor betterend:pythadendron_door betterend:pythadendron_ladder betterend:pythadendron_taburet betterend:pythadendron_bar_stool betterend:pythadendron_chair betterend:pythadendron_wall
+betterend:tenanea_composter betterend:tenanea_chest betterend:tenanea_stairs betterend:tenanea_slab betterend:tenanea_fence betterend:tenanea_gate betterend:tenanea_button betterend:tenanea_plate betterend:tenanea_trapdoor betterend:tenanea_door betterend:tenanea_ladder betterend:tenanea_taburet betterend:tenanea_bar_stool betterend:tenanea_chair betterend:tenanea_wall betterend:pythadendron_composter betterend:pythadendron_chest betterend:pythadendron_stairs betterend:pythadendron_slab betterend:pythadendron_fence betterend:pythadendron_gate betterend:pythadendron_button betterend:pythadendron_plate betterend:pythadendron_trapdoor betterend:pythadendron_door betterend:pythadendron_ladder betterend:pythadendron_taburet betterend:pythadendron_bar_stool betterend:pythadendron_chair betterend:pythadendron_wall \
+\
+create:crimson_window create:crimson_window_pane
 
 # Crimson Wood Powered Blocks - Euphoria Patches Redstone IPBR
 block.10215 = crimson_fence_gate:powered=true crimson_button:powered=true crimson_pressure_plate:powered=true
@@ -915,6 +957,8 @@ block.10221 = warped_fence warped_fence_gate:powered=false warped_button:powered
 betternether:warped_ladder betternether:warped_taburet betternether:warped_bar_stool betternether:warped_chair betternether:warped_composter betternether:warped_chest betternether:stalagnate_chest betternether:stalagnate_bowl betternether:stalagnate_composter betternether:stalagnate_fence betternether:stalagnate_gate betternether:stalagnate_wall betternether:stalagnate_ladder betternether:stalagnate_plate betternether:stalagnate_button betternether:stalagnate_bar_stool betternether:stalagnate_slab betternether:stalagnate_stairs betternether:stalagnate_roof_stairs betternether:stalagnate_roof_slab betternether:stalagnate_trapdoor betternether:stalagnate_door betternether:stalagnate_chair betternether:stalagnate_stem betternether:stalagnate_taburet betternether:nether_reed_chest betternether:nether_reed_composter betternether:nether_reed_fence betternether:nether_reed_gate betternether:nether_reed_wall betternether:nether_reed_ladder betternether:nether_reed_plate betternether:nether_reed_button betternether:nether_reed_bar_stool betternether:nether_reed_slab betternether:nether_reed_stairs betternether:nether_reed_roof_stairs betternether:nether_reed_roof_slab betternether:nether_reed_trapdoor betternether:nether_reed_door betternether:nether_reed_chair betternether:nether_reed_taburet betternether:mushroom_fir_chest betternether:mushroom_fir_trimmed_chest betternether:mushroom_fir_composter betternether:mushroom_fir_fence betternether:mushroom_fir_gate betternether:mushroom_fir_wall betternether:mushroom_fir_ladder betternether:mushroom_fir_plate betternether:mushroom_fir_button betternether:mushroom_fir_bar_stool betternether:mushroom_fir_slab betternether:mushroom_fir_stairs betternether:mushroom_fir_trapdoor betternether:mushroom_fir_door betternether:mushroom_fir_chair betternether:mushroom_fir_stem betternether:mushroom_fir_taburet betternether:anchor_tree_chest betternether:anchor_tree_composter betternether:anchor_tree_fence betternether:anchor_tree_gate betternether:anchor_tree_wall betternether:anchor_tree_ladder betternether:anchor_tree_plate betternether:anchor_tree_button betternether:anchor_tree_bar_stool betternether:anchor_tree_slab betternether:anchor_tree_stairs betternether:anchor_tree_trapdoor betternether:anchor_tree_door betternether:anchor_tree_chair betternether:anchor_tree_taburet \
 \
 betterend:mossy_glowshroom_composter betterend:mossy_glowshroom_chest betterend:mossy_glowshroom_stairs betterend:mossy_glowshroom_slab betterend:mossy_glowshroom_fence betterend:mossy_glowshroom_gate betterend:mossy_glowshroom_button betterend:mossy_glowshroom_plate betterend:mossy_glowshroom_trapdoor betterend:mossy_glowshroom_door betterend:mossy_glowshroom_ladder betterend:mossy_glowshroom_taburet betterend:mossy_glowshroom_bar_stool betterend:mossy_glowshroom_chair betterend:mossy_glowshroom_wall betterend:jellyshroom_composter betterend:jellyshroom_chest betterend:jellyshroom_stairs betterend:jellyshroom_slab betterend:jellyshroom_fence betterend:jellyshroom_gate betterend:jellyshroom_button betterend:jellyshroom_plate betterend:jellyshroom_trapdoor betterend:jellyshroom_door betterend:jellyshroom_ladder betterend:jellyshroom_taburet betterend:jellyshroom_bar_stool betterend:jellyshroom_chair betterend:jellyshroom_wall \
+\
+create:warped_window create:warped_window_pane \
 \
 supplementaries:lapis_bricks_stairs supplementaries:lapis_bricks_vertical_slab supplementaries:lapis_bricks_slab supplementaries:lapis_bricks_wall 
 
@@ -970,11 +1014,15 @@ block.10244 = red_sandstone smooth_red_sandstone chiseled_red_sandstone cut_red_
 # Red Sandstone Non-Full Block
 block.10245 = red_sandstone_wall stone_slab2 red_sandstone_slab cut_red_sandstone_slab red_sandstone_stairs smooth_red_sandstone_stairs smooth_red_sandstone_slab
 
-block.10248 = netherite_block
+block.10248 = netherite_block  \
+\
+create:industrial_iron_block create:andesite_alloy_block create:metal_girder
 
 block.10252 = ancient_debris
 
 block.10257 = iron_bars \
+\
+create:ornate_iron_window create:ornate_iron_window_pane \
 \
 supplementaries:iron_gate
 
@@ -988,6 +1036,12 @@ block.10263 = iron_door:powered=true iron_trapdoor:powered=true
 
 block.10264 = iron_block \
 \
+biomesoplenty:rose_quartz_block \
+\
+cobblemon:monitor cobblemon:pc cobblemon:healing_machine \
+\
+create:small_rose_quartz_tiles create:rose_quartz_tiles create:rose_quartz_block create:zinc_block \
+\
 raitherts:iron_block_slab \
 \
 mob_grinding_utils:xp_tap
@@ -999,7 +1053,9 @@ block.10265 = heavy_weighted_pressure_plate:power=0
 block.10267 = heavy_weighted_pressure_plate:power=1 heavy_weighted_pressure_plate:power=2 heavy_weighted_pressure_plate:power=3 heavy_weighted_pressure_plate:power=4 heavy_weighted_pressure_plate:power=5 heavy_weighted_pressure_plate:power=6 heavy_weighted_pressure_plate:power=7 heavy_weighted_pressure_plate:power=8 heavy_weighted_pressure_plate:power=9 heavy_weighted_pressure_plate:power=10 heavy_weighted_pressure_plate:power=11 heavy_weighted_pressure_plate:power=12 heavy_weighted_pressure_plate:power=13 heavy_weighted_pressure_plate:power=14 heavy_weighted_pressure_plate:power=15
 
 # Euphoria Patches Glowing Raw Blocks
-block.10268 = raw_iron_block
+block.10268 = raw_iron_block \
+\
+create:raw_zinc_block
 
 # Glowing Ores
 block.10272 = iron_ore \
@@ -1034,15 +1090,27 @@ create_new_age:thorium_ore \
 undergarden:shiverstone_utherium_ore undergarden:depthrock_utherium_ore
 
 # Glowing Ores
-block.10288 = deepslate_copper_ore
+block.10288 = deepslate_copper_ore \
+\
+cobblemon:moon_stone_ore cobblemon:deepslate_moon_stone_ore \
+\
+deeperdarker:gloomslate_copper_ore deeperdarker:sculk_stone_copper_ore
 
 # Copper Full Blocks
 block.10292 = copper_block exposed_copper weathered_copper oxidized_copper cut_copper exposed_cut_copper weathered_cut_copper oxidized_cut_copper waxed_copper_block waxed_exposed_copper waxed_weathered_copper waxed_oxidized_copper waxed_cut_copper waxed_exposed_cut_copper waxed_weathered_cut_copper waxed_oxidized_cut_copper chiseled_copper exposed_chiseled_copper weathered_chiseled_copper oxidized_chiseled_copper waxed_chiseled_copper waxed_exposed_chiseled_copper waxed_weathered_chiseled_copper waxed_oxidized_chiseled_copper \
 \
-supplementaries:cog_block
+supplementaries:cog_block \
+\
+create:copper_shingles create:waxed_copper_shingles create:copper_tiles create:waxed_copper_tiles create:copper_casing create:weathered_copper_shingles create:waxed_weathered_copper_shingles create:weathered_copper_tiles create:waxed_weathered_copper_tiles create:weathered_copper_casing \
+\
+quark:raw_copper_bricks
 
 # Copper Non-Full Blocks
-block.10293 = lightning_rod cut_copper_stairs exposed_cut_copper_stairs weathered_cut_copper_stairs oxidized_cut_copper_stairs cut_copper_slab exposed_cut_copper_slab weathered_cut_copper_slab oxidized_cut_copper_slab waxed_cut_copper_stairs waxed_exposed_cut_copper_stairs waxed_weathered_cut_copper_stairs waxed_oxidized_cut_copper_stairs waxed_cut_copper_slab waxed_exposed_cut_copper_slab waxed_weathered_cut_copper_slab waxed_oxidized_cut_copper_slab copper_grate exposed_copper_grate weathered_copper_grate oxidized_copper_grate waxed_copper_grate waxed_exposed_copper_grate waxed_weathered_copper_grate waxed_oxidized_copper_grate
+block.10293 = lightning_rod cut_copper_stairs exposed_cut_copper_stairs weathered_cut_copper_stairs oxidized_cut_copper_stairs cut_copper_slab exposed_cut_copper_slab weathered_cut_copper_slab oxidized_cut_copper_slab waxed_cut_copper_stairs waxed_exposed_cut_copper_stairs waxed_weathered_cut_copper_stairs waxed_oxidized_cut_copper_stairs waxed_cut_copper_slab waxed_exposed_cut_copper_slab waxed_weathered_cut_copper_slab waxed_oxidized_cut_copper_slab copper_grate exposed_copper_grate weathered_copper_grate oxidized_copper_grate waxed_copper_grate waxed_exposed_copper_grate waxed_weathered_copper_grate waxed_oxidized_copper_grate \
+\
+create:fluid_pipe create:fluid_tank create:hose_pulley create:item_drain create:spout create:copper_valve_handle create:mechanical_pump create:smart_fluid_pipe create:fluid_valve create:portable_fluid_interface create:steam_engine create:steam_whistle create:copper_ladder create:copper_scaffolding create:copper_door create:copper_bars create:copper_shingle_slab create:copper_shingle_stairs create:waxed_copper_shingle_stairs create:copper_tile_slab create:copper_tile_stairs create:waxed_copper_tile_slab create:waxed_copper_tile_stairs create:weathered_copper_shingle_slab create:weathered_copper_shingle_stairs create:waxed_weathered_copper_shingle_stairs create:weathered_copper_tile_slab create:weathered_copper_tile_stairs create:waxed_weathered_copper_tile_slab create:waxed_weathered_copper_tile_stairs \
+\
+quark:raw_copper_bricks_stairs quark:raw_copper_bricks_slab quark:raw_copper_bricks_wall
 
 # Euphoria Patches Glowing Raw Blocks
 block.10296 = raw_gold_block
@@ -1071,20 +1139,36 @@ undergarden:shiverstone_regalium_ore undergarden:depthrock_regalium_ore
 # Glowing Ores
 block.10304 = deepslate_gold_ore \
 \
-thermal:deepslate_sulfur_ore thermal:deepslate_nickel_ore
+thermal:deepslate_sulfur_ore thermal:deepslate_nickel_ore \
+\
+cobblemon:sun_stone_ore cobblemon:deepslate_sun_stone_ore \
+\
+deeperdarker:gloomslate_gold_ore deeperdarker:sculk_stone_gold_ore
 
 # Glowing Ores
 block.10308 = nether_gold_ore \
 \
 betternether:cincinnasite_ore \
 \
-byg:blue_nether_gold_ore byg:brimstone_nether_gold_ore
+byg:blue_nether_gold_ore byg:brimstone_nether_gold_ore \
+\
+cobblemon:nether_fire_stone_ore cobblemon:terracotta_sun_stone_ore cobblemon:fire_stone_ore cobblemon:deepslate_fire_stone_ore
 
 block.10312 = gold_block \
 \
 betternether:cincinnasite_tile_large betternether:cincinnasite_forged betternether:cincinnasite_bricks betternether:cincinnasite_tile_small betternether:roof_tile_cincinnasite betternether:cincinnasite_pillar betternether:cincinnasite_brick_plate betternether:cincinnasite_carved betternether:cincinnasite_bricks_pillar betternether:cincinnasite_block \
 \
-betterend:brimstone betterend:respawn_obelisk:shape=bottom betterend:amber_block
+betterend:brimstone betterend:respawn_obelisk:shape=bottom betterend:amber_block \
+\
+create:brass_casing create:mechanical_crafter create:sequenced_gearshift create:flywheel create:rotation_speed_controller create:mechanical_arm create:railwaycasing create:controls create:brass_funnel create:smart_chute create:brass_tunnel create:content_observer create:stockpile_switch create:display_link create:redstone_link create:peculiar_bell create:brass_ladder create:brass_bars create:brass_block create:brass_door create:brass_scafolding create:brass_trapdoor \
+\
+cobblemon:relic_coin_sack cobblemon:relic_coin_pouch \
+\
+handcrafted:golden_thin_pot handcrafted:golden_thick_pot handcrafted:golden_medium_pot handcrafted:golden_wide_pot handcrafted:yellow_bowl handcrafted:yellow_cup handcrafted:yellow_crockery_combo handcrafted:yellow_plate \
+\
+quark:raw_gold_bricks quark:raw_gold_bricks_stairs quark:raw_gold_bricks_slab quark:raw_gold_bricks_wall quark:gold_bars quark:golden_apple_crate quark:golden_carrot_crate \
+\
+supplementaries:gold_gate supplementaries:gold_door supplementaries:gold_trapdoor
 
 # Unpowered Light Weighted Pressure Plate - Euphoria Patches Redstone IPBR
 block.10313 = light_weighted_pressure_plate:power=0 \
@@ -1136,7 +1220,13 @@ block.10324 = deepslate_diamond_ore \
 \
 thermal:deepslate_tin_ore \
 \
-forbidden_arcanus:deepslate_arcane_crystal_ore
+forbidden_arcanus:deepslate_arcane_crystal_ore \
+\
+deeperdarker:gloomslate_diamond_ore deeperdarker:sculk_stone_diamond_ore \
+\
+cobblemon:deepslate_ice_stone_ore cobblemon:dawn_stone_ore cobblemon:deepslate_dawn_stone_ore cobblemon:ice_stone_ore \
+\
+nethersdelight:rich_soul_soil nethersdelight:soul_compost
 
 # Amethyst Blocks
 block.10328 = amethyst_block budding_amethyst \
@@ -1159,8 +1249,6 @@ galosphere:allurite_cluster galosphere:lumiere_cluster galosphere:glinted_alluri
 quark:red_corundum_cluster quark:orange_corundum_cluster quark:yellow_corundum_cluster quark:green_corundum_cluster quark:blue_corundum_cluster quark:indigo_corundum_cluster quark:violet_corundum_cluster quark:white_corundum_cluster quark:black_corundum_cluster \
 \
 ae2:quartz_cluster \
-\
-biomesoplenty:rose_quartz_cluster \
 \
 biomemakeover:illunite_cluster biomemakeover:large_illunite_bud biomemakeover:medium_illunite_bud biomemakeover:small_illunite_bud
 
@@ -1221,10 +1309,14 @@ theabyss:incorythe_ore \
 \
 ad_astra:blue_industrial_lamp ad_astra:small_blue_industrial_lamp ad_astra:black_industrial_lamp ad_astra:small_black_industrial_lamp \
 \
-alexscaves:radon_lamp_blue alexscaves:radon_lamp_black
+alexscaves:radon_lamp_blue alexscaves:radon_lamp_black \
+\
+quark:blue_crystal_lamp:lit=true
 
 # Glowing Ores
 block.10360 = deepslate_lapis_ore \
+\
+alexscaves:radon_lamp_blue \
 \
 betternether:blue_crying_obsidian \
 \
@@ -1232,7 +1324,11 @@ betterend:thallasium_bulb_lantern_blue betterend:terminite_bulb_lantern_blue bet
 \
 thermal:deepslate_lead_ore \
 \
-beo:end_lapis_ore
+beo:end_lapis_ore \
+\
+cobblemon:water_stone_ore cobblemon:deepslate_water_stone_ore \
+\
+deeperdarker:sculk_stone_lapis_ore deeperdarker:gloomslate_lapis_ore
 
 
 ##### QUARTZ #####
@@ -1420,7 +1516,9 @@ supplementaries:prismarine_rod
 
 block.10448 = sea_lantern \
 \
-betternether:willow_branch:shape=end betternether:willow_torch betternether:eye_seed betternether:eyeball_small betternether:eyeball
+betternether:willow_branch:shape=end betternether:willow_torch betternether:eye_seed betternether:eyeball_small betternether:eyeball \
+\
+quark:white_crystal_lamp:lit=true
 
 block.10452 = magma magma_block \
 \
@@ -1614,7 +1712,9 @@ block.10562 = lantern:hanging=true \
 \
 amendments:wall_lantern:light_level=15 \
 \
-supplementaries:wall_lantern:light_level=15
+supplementaries:wall_lantern:light_level=15 \
+\
+quark:blaze_lantern
 
 block.10564 = soul_lantern \
 \
@@ -1626,7 +1726,9 @@ additionallanterns:light_blue_amethyst_lantern additionallanterns:light_blue_and
 \
 amendments:wall_lantern:light_level=10 \
 \
-supplementaries:wall_lantern:light_level=10
+supplementaries:wall_lantern:light_level=10 \
+\
+quark:indigo_crystal_lamp:lit=true
 
 block.10569 = turtle_egg sniffer_egg
 
@@ -1669,7 +1771,9 @@ supplementaries:crimson_lantern:lit=true \
 additionallanterns:red_amethyst_lantern additionallanterns:red_andesite_lantern additionallanterns:red_basalt_lantern additionallanterns:red_blackstone_lantern additionallanterns:red_bone_lantern additionallanterns:red_bricks_lantern additionallanterns:red_cobbled_deepslate_lantern additionallanterns:red_cobblestone_lantern additionallanterns:red_copper_lantern additionallanterns:red_crimson_lantern additionallanterns:red_dark_prismarine_lantern additionallanterns:red_deepslate_bricks_lantern additionallanterns:red_diamond_lantern additionallanterns:red_diorite_lantern additionallanterns:red_emerald_lantern additionallanterns:red_end_stone_lantern additionallanterns:red_exposed_copper_lantern additionallanterns:red_gold_lantern  additionallanterns:red_granite_lantern additionallanterns:red_iron_lantern additionallanterns:red_mossy_cobblestone_lantern additionallanterns:red_netherite_lantern additionallanterns:red_normal_lantern additionallanterns:red_normal_nether_bricks_lantern additionallanterns:red_normal_sandstone_lantern additionallanterns:red_obsidian_lantern additionallanterns:red_oxidized_copper_lantern additionallanterns:red_prismarine_lantern additionallanterns:red_purpur_lantern additionallanterns:red_quartz_lantern additionallanterns:red_red_nether_bricks_lantern additionallanterns:red_red_sandstone_lantern additionallanterns:red_smooth_stone_lantern additionallanterns:red_stone_bricks_lantern additionallanterns:red_stone_lantern additionallanterns:red_warped_lantern additionallanterns:red_waxed_copper_lantern additionallanterns:red_waxed_exposed_copper_lantern additionallanterns:red_waxed_oxidized_copper_lantern additionallanterns:red_waxed_weathered_copper_lantern additionallanterns:red_weathered_copper_lantern
 
 # Redstone Torch Unlit (Turned Off)
-block.10605 = redstone_torch:lit=false redstone_wall_torch:lit=false
+block.10605 = redstone_torch:lit=false redstone_wall_torch:lit=false \
+\
+biomesoplenty:rose_quartz_cluster biomesoplenty:small_rose_quartz_bud biomesoplenty:medium_rose_quartz_bud biomesoplenty:large_rose_quartz_bud
 
 block.10608 = redstone_block
 #if MC_VERSION >= 11300
@@ -1683,7 +1787,7 @@ ad_astra:red_industrial_lamp ad_astra:small_red_industrial_lamp \
 \
 createdeco:red_industrial_iron_lamp:lit=true createdeco:red_andesite_lamp:lit=true createdeco:red_brass_lamp:lit=true createdeco:red_iron_lamp:lit=true createdeco:red_copper_lamp:lit=true createdeco:red_zinc_lamp:lit=true \
 \
-alexscaves:radon_lamp_red
+alexscaves:radon_lamp_red alexscaves:guanostone_redstone_ore:lit=false
 
 block.10616 = redstone_ore:lit=true \
 \
@@ -1707,7 +1811,11 @@ deep_dark_regrowth:grimstone_redstone_ore:lit=true \
 \
 organics:nether_redstone_ore:lit=true \
 \
-theabyss:ignisithe_ore
+theabyss:ignisithe_ore \
+\
+quark:red_crystal_lamp:lit=true \
+\
+supplementaries:blackstone_lamp
 
 #else
 block.10612 = redstone_ore
@@ -1772,7 +1880,11 @@ supplementaries:copper_lantern:lit=true supplementaries:brass_lantern:lit=true \
 \
 ad_astra:orange_industrial_lamp ad_astra:small_orange_industrial_lamp ad_astra:brown_industrial_lamp ad_astra:small_brown_industrial_lamp \
 \
-alexscaves:radon_lamp_orange alexscaves:radon_lamp_brown
+alexscaves:radon_lamp_orange alexscaves:radon_lamp_brown \
+\
+quark:orange_crystal_lamp:lit=true \
+\
+supplementaries:deepslate_lamp
 
 # Campfire Lit
 block.10652 = campfire:lit=true \
@@ -1832,7 +1944,11 @@ astrological:ochre_selenite \
 \
 betternether:lucis_spore betternether:lucis_mushroom betternether:jellyfish_mushroom:visual=poor betternether:golden_vine \
 \
-betterend:cave_pumpkin betterend:cave_pumpkin_seed:age=3 betterend:large_amaranita_mushroom:shape=top betterend:filalux_lantern betterend:thallasium_bulb_lantern_brown betterend:terminite_bulb_lantern_brown betterend:iron_bulb_lantern_brown
+betterend:cave_pumpkin betterend:cave_pumpkin_seed:age=3 betterend:large_amaranita_mushroom:shape=top betterend:filalux_lantern betterend:thallasium_bulb_lantern_brown betterend:terminite_bulb_lantern_brown betterend:iron_bulb_lantern_brown \
+\
+quark:yellow_crystal_lamp:lit=true \
+\
+supplementaries:redstone_illuminator
 
 block.10684 = verdant_froglight \
 \
@@ -1846,7 +1962,11 @@ betterend:thallasium_bulb_lantern_green betterend:terminite_bulb_lantern_green b
 \
 supplementaries:sconce_green:lit=true supplementaries:sconce_wall_green:lit=true \
 \
-additionallanterns:green_amethyst_lantern additionallanterns:green_andesite_lantern additionallanterns:green_basalt_lantern additionallanterns:green_blackstone_lantern additionallanterns:green_bone_lantern additionallanterns:green_bricks_lantern additionallanterns:green_cobbled_deepslate_lantern additionallanterns:green_cobblestone_lantern additionallanterns:green_copper_lantern additionallanterns:green_crimson_lantern additionallanterns:green_dark_prismarine_lantern additionallanterns:green_deepslate_bricks_lantern additionallanterns:green_diamond_lantern additionallanterns:green_diorite_lantern additionallanterns:green_emerald_lantern additionallanterns:green_end_stone_lantern additionallanterns:green_exposed_copper_lantern additionallanterns:green_gold_lantern  additionallanterns:green_granite_lantern additionallanterns:green_iron_lantern additionallanterns:green_mossy_cobblestone_lantern additionallanterns:green_netherite_lantern additionallanterns:green_normal_lantern additionallanterns:green_normal_nether_bricks_lantern additionallanterns:green_normal_sandstone_lantern additionallanterns:green_obsidian_lantern additionallanterns:green_oxidized_copper_lantern additionallanterns:green_prismarine_lantern additionallanterns:green_purpur_lantern additionallanterns:green_quartz_lantern additionallanterns:green_red_nether_bricks_lantern additionallanterns:green_red_sandstone_lantern additionallanterns:green_smooth_stone_lantern additionallanterns:green_stone_bricks_lantern additionallanterns:green_stone_lantern additionallanterns:green_warped_lantern additionallanterns:green_waxed_copper_lantern additionallanterns:green_waxed_exposed_copper_lantern additionallanterns:green_waxed_oxidized_copper_lantern additionallanterns:green_waxed_weathered_copper_lantern additionallanterns:green_weathered_copper_lantern
+additionallanterns:green_amethyst_lantern additionallanterns:green_andesite_lantern additionallanterns:green_basalt_lantern additionallanterns:green_blackstone_lantern additionallanterns:green_bone_lantern additionallanterns:green_bricks_lantern additionallanterns:green_cobbled_deepslate_lantern additionallanterns:green_cobblestone_lantern additionallanterns:green_copper_lantern additionallanterns:green_crimson_lantern additionallanterns:green_dark_prismarine_lantern additionallanterns:green_deepslate_bricks_lantern additionallanterns:green_diamond_lantern additionallanterns:green_diorite_lantern additionallanterns:green_emerald_lantern additionallanterns:green_end_stone_lantern additionallanterns:green_exposed_copper_lantern additionallanterns:green_gold_lantern  additionallanterns:green_granite_lantern additionallanterns:green_iron_lantern additionallanterns:green_mossy_cobblestone_lantern additionallanterns:green_netherite_lantern additionallanterns:green_normal_lantern additionallanterns:green_normal_nether_bricks_lantern additionallanterns:green_normal_sandstone_lantern additionallanterns:green_obsidian_lantern additionallanterns:green_oxidized_copper_lantern additionallanterns:green_prismarine_lantern additionallanterns:green_purpur_lantern additionallanterns:green_quartz_lantern additionallanterns:green_red_nether_bricks_lantern additionallanterns:green_red_sandstone_lantern additionallanterns:green_smooth_stone_lantern additionallanterns:green_stone_bricks_lantern additionallanterns:green_stone_lantern additionallanterns:green_warped_lantern additionallanterns:green_waxed_copper_lantern additionallanterns:green_waxed_exposed_copper_lantern additionallanterns:green_waxed_oxidized_copper_lantern additionallanterns:green_waxed_weathered_copper_lantern additionallanterns:green_weathered_copper_lantern \
+\
+create:experience_block \
+\
+quark:green_crystal_lamp:lit=true
 
 block.10688 = pearlescent_froglight supplementaries:sconce_ender:lit=true supplementaries:sconce_wall_ender:lit=true \
 \
@@ -1883,7 +2003,14 @@ block.10700 = sculk_shrieker
 # Active Sculk Sensor
 block.10704 = sculk_sensor:sculk_sensor_phase=active
 
-block.10708 = mob_spawner spawner
+block.10708 = mob_spawner spawner \
+\
+alexscaves:radon_lamp_purple alexscaves:radon_lamp_magenta \
+\
+create:rose_quartz_lamp \
+\
+quark:violet_crystal_lamp:lit=true quark:monster_box
+
 
 block.10712 = tuff chiseled_tuff polished_tuff tuff_bricks chiseled_tuff_bricks
 


### PR DESCRIPTION
- Create: All Wooden Windows, Copper, Brass, Rose Quartz, Andesite, Gold, Calcite blocks and tiles and some immobile contraptions.

- BOP: Parity changes for Create's rose quartz

- Supplementaries: Some decorative blocks

- Handcrafted: Some Minor Decoratives

- DeeperDarker: Glores compat

- Alex's Caves: Minor adjustments to colored lights

- Quark: Calcite, Colored Redstone Lamps, and other minor additions

- Cobblemon: Autolight detection fix for Monitors, New Wood Type, Glores compat, Some minor decoratives.