### PR TITLE
Add Create's dyed nixie tubes

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -6663,7 +6663,7 @@ immersive_weathering:frosty_glass_pane \
 \
 tconstruct:clear_glass_pane tconstruct:soul_glass_pane tconstruct:seared_glass_pane tconstruct:seared_soul_glass_pane tconstruct:scorched_glass_pane tconstruct:scorched_soul_glass_pane \
 \
-create:nixie_tube create:framed_glass_door create:framed_glass_trapdoor create:tiled_glass_pane create:framed_glass_pane create:horizontal_framed_glass_pane create:vertical_framed_glass_pane \
+create:nixie_tube create:framed_glass_door create:framed_glass_trapdoor create:tiled_glass_pane create:framed_glass_pane create:horizontal_framed_glass_pane create:vertical_framed_glass_pane create:white_nixie_tube create:light_gray_nixie_tube create:gray_nixie_tube create:black_nixie_tube create:brown_nixie_tube create:red_nixie_tube create:yellow_nixie_tube create:lime_nixie_tube create:green_nixie_tube create:cyan_nixie_tube create:light_blue_nixie_tube create:blue_nixie_tube create:purple_nixie_tube create:magenta_nixie_tube create:pink_nixie_tube \
 \
 createdeco:andesite_window_pane createdeco:copper_window_pane createdeco:iron_window_pane createdeco:industrial_iron_window_pane createdeco:brass_window_pane createdeco:zinc_window_pane \
 \


### PR DESCRIPTION
The default nixie tube is orange, so there is no `orange_nixie_tube` block.