### PR TITLE
changed some galosphere entries so they don't just give off purple ACL.

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -3333,7 +3333,7 @@ securitycraft:deepslate_diamond_mine \
 \
 born_in_chaos_v1:infected_deepslate_diamond_ore \
 \
-alltheores:deepslate_sapphire_ore
+alltheores:deepslate_sapphire_ore \
 
 # Amethyst Blocks
 block.10328 = amethyst_block budding_amethyst \
@@ -3386,8 +3386,6 @@ mythicupgrades:ruby_crystal_cluster mythicupgrades:topaz_crystal_cluster mythicu
 hydrol:glowing_amethyst \
 \
 byg:ametrine_cluster byg:subzero_crystal_cluster byg:therium_crystal_cluster \
-\
-galosphere:lumiere_cluster galosphere:glinted_lumiere_cluster galosphere:glinted_amethyst_cluster \
 \
 ae2:quartz_cluster ae2:medium_quartz_bud  ae2:small_quartz_bud  ae2:large_quartz_bud \
 \
@@ -4643,7 +4641,9 @@ bountifulfares:feldspar_lantern:hanging=false bountifulfares:feldspar_lamp:lit=t
 \
 cinderscapes:potted_crystinium \
 \
-antiblocksrechiseled:bright_orange
+antiblocksrechiseled:bright_orange \
+\
+galosphere:glinted_lumiere_cluster galosphere:lumiere_cluster 
 
 # Hanging Lantern
 block.10562 = lantern:hanging=true \
@@ -4893,10 +4893,14 @@ mythicmetals:deepslate_adamantite_ore \
 securitycraft:deepslate_redstone_mine:lit=true
 
 # Cave Vines Berries False
-block.10629 = cave_vines_plant:berries=false cave_vines:berries=false
+block.10629 = cave_vines_plant:berries=false cave_vines:berries=false \
+\
+deeperdarker:glowing_vines_plant:berries=false
 
 # Cave Vines Berries True
-block.10632 = cave_vines_plant:berries=true cave_vines:berries=true
+block.10632 = cave_vines_plant:berries=true cave_vines:berries=true \
+\
+deeperdarker:glowing_vines_plant:berries=true
 
 #if MC_VERSION >= 11300
 # Redstone Lamp Unlit

--- a/block.properties
+++ b/block.properties
@@ -3333,7 +3333,7 @@ securitycraft:deepslate_diamond_mine \
 \
 born_in_chaos_v1:infected_deepslate_diamond_ore \
 \
-alltheores:deepslate_sapphire_ore \
+alltheores:deepslate_sapphire_ore
 
 # Amethyst Blocks
 block.10328 = amethyst_block budding_amethyst \


### PR DESCRIPTION
For some reason the orange crystals from galosphere were under budding amethyst making the orange block give off purple ACL. This PR fixes it
![Example](https://cdn.discordapp.com/attachments/1229394890086023258/1291654433884868648/2024-10-03_22.17.28.png?ex=6700e26e&is=66ff90ee&hm=9f90daadf71126b0f6947e8e113079c8561ad5e1a90c657f3899278c86920315&)