### PR TITLE
Update block.properties

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -818,7 +818,15 @@ modern_industrialization:deepslate_antimony_ore modern_industrialization:antimon
 \
 silentgear:deepslate_bort_ore silentgear:bort_ore  \
 \
-xycraft_world:xychorium_ore_deepslate_dark xycraft_world:xychorium_ore_stone_dark xycraft_world:xychorium_ore_deepslate_light xycraft_world:xychorium_ore_stone_light xycraft_world:xychorium_ore_kivi_dark xycraft_world:xychorium_ore_kivi_light
+xycraft_world:xychorium_ore_deepslate_dark xycraft_world:xychorium_ore_stone_dark xycraft_world:xychorium_ore_deepslate_light xycraft_world:xychorium_ore_stone_light xycraft_world:xychorium_ore_kivi_dark xycraft_world:xychorium_ore_kivi_light \
+\
+bewitchment:salt_ore \
+\
+techreborn:tin_ore techreborn:deepslate_tin_ore \
+\
+modern_industrialization:nickel_ore modern_industrialization:deepslate_nickel_ore \
+\
+eldritch_end:etyr_ore
 
 # Short Foliage / Foliage Lower Half - No Subsurface Scattering
 block.10025 =
@@ -834,7 +842,9 @@ silentgear:crimson_iron_ore \
 \
 rftoolsbase:dimensionalshard_nether \
 \
-bigreactors:benitoite_ore
+bigreactors:benitoite_ore \
+\
+techreborn:sphalerite_ore techreborn:pyrite_ore techreborn:cinnabar_ore
 
 # Tall Foliage / Foliage Upper Half - No Subsurface Scattering
 block.10027 =
@@ -3026,9 +3036,7 @@ undergarden:depthrock_iron_ore  \
 \
 ad_astra:moon_iron_ore ad_astra:mars_iron_ore ad_astra:mercury_iron_ore ad_astra:glacio_iron_ore \
 \
-securitycraft:iron_mine \
-\
-techreborn:sphalerite_ore
+securitycraft:iron_mine
 
 # Deepslate Variant
 block.10276 = deepslate_iron_ore \
@@ -3077,7 +3085,7 @@ ad_astra:moon_desh_ore ad_astra:glacio_copper_ore \
 \
 securitycraft:copper_mine \
 \
-techreborn:bauxite_ore techreborn:cinnabar_ore techreborn:pyrite_ore 
+techreborn:bauxite_ore
 
 # Deepslate Variant
 block.10288 = deepslate_copper_ore \
@@ -3243,7 +3251,9 @@ securitycraft:deepslate_gold_mine \
 \
 infinite_abyss:seventh_layer_molten_deepstone \
 \
-bigreactors:deepslate_yellorite_ore
+bigreactors:deepslate_yellorite_ore \
+\
+deeperdarker:gloomy_sculk
 
 
 # Pink Modded Ores
@@ -3278,7 +3288,10 @@ organics:endium_ore \
 \
 theurgy:sal_ammoniac_ore theurgy:deepslate_sal_ammoniac_ore \
 \
-evilcraft:dark_ore_deepslate evilcraft:dark_ore
+evilcraft:dark_ore_deepslate evilcraft:dark_ore \
+\
+techreborn:galena_ore techreborn:deepslate_galena_ore techreborn:lead_ore techreborn:deepslate_lead_ore
+
 
 # Glowing Ores Nether Gold
 block.10308 = nether_gold_ore \
@@ -3743,7 +3756,7 @@ securitycraft:lapis_mine \
 \
 xycraft_world:xychorium_ore_stone_blue \
 \
-techreborn:sapphire_ore techreborn:sheldonite_ore techreborn:galena_ore techreborn:lead_ore techreborn:tungsten_ore \
+techreborn:sapphire_ore techreborn:sheldonite_ore \
 \
 soulsweapons:verglas_ore 
 
@@ -3865,7 +3878,7 @@ alltheores:other_quartz_ore \
 \
 infinite_abyss:opal_ore infinite_abyss:deepsilver_ore infinite_abyss:cursed_opal_ore \
 \
-techreborn:silver_ore techreborn:deepslate_silver_ore techreborn:iridium_ore techreborn:deepslate_iridium_ore techreborn:tin_ore techreborn:deepslate_tin_ore techreborn:deepslate_sheldonite_ore 
+techreborn:silver_ore techreborn:deepslate_silver_ore techreborn:iridium_ore techreborn:deepslate_iridium_ore techreborn:deepslate_sheldonite_ore 
 
 # Obsidian Full Blocks
 block.10372 = obsidian \
@@ -3912,7 +3925,7 @@ diagonalfences:extshape_blockus/glowing_obsidian_fence diagonalfences:extshape/o
 \
 securitycraft:protecto \
 \
-additionallanterns:obsidian_chain \
+additionallanterns:obsidian_chain
 
 # Full Purpur Blocks
 block.10376 = purpur_block purpur_pillar \


### PR DESCRIPTION
adds emissive ores to 
eldritch end
bewitchment

fixes already added emissive ores to look a bit better some of them lose ACL for better emissive color

techreborn: pyrite_ore, cinnabar_ore and some others.

added a flickering glow to the gloomy sculk from deeper and darker mod

added proper glow to nickel ore from modern industrialization
