### PR TITLE
Added all ores from Hexxit II Modpack

### DIFF
--- a/addedMods.md
+++ b/addedMods.md
@@ -134,7 +134,7 @@ Here we can keep track of what mods has been added and what version a contributo
 | [Extended block shapes](https://modrinth.com/mod/extshape/version/2.2.1-fabric-1.20.1) | 2.2.1 | Fully Added | # Total fucking anguish trying to add this. 
 | [Extended Block Shapes - Blockus](https://modrinth.com/mod/extshape_blockus) | 2.1.4 | Fully Added | # Same with you
 | [Extractinator](https://modrinth.com/mod/extractinator) | 2.3.0 | Fully Added |
-| [Eyes in the Darkness](https://www.curseforge.com/minecraft/mc-mods/eyes-in-the-darkness) | 0.1.0 |  Fully Added |
+| [Eyes in the Darkness](https://www.curseforge.com/minecraft/mc-mods/eyes-in-the-darkness) | 0.1.0 | Fully Added |
 | [Fabric Seasons: Extras](https://modrinth.com/mod/fabric-seasons-extras) | 1.2-BETA | Fully Added |
 | [The Farlanders](https://modrinth.com/mod/the-farlanders) | | Miniscule |
 | [\[Let's Do\] Farm & Charm](https://modrinth.com/mod/lets-do-farm-charm) | | Partial Support |
@@ -191,6 +191,7 @@ Here we can keep track of what mods has been added and what version a contributo
 | [Midnight Madness](https://modrinth.com/mod/midnight-madness) | | Partial Support |
 | [MineCells](https://www.curseforge.com/minecraft/mc-mods/minecells) | 1.9.1 | Miniscule | #added emissive torches
 | [Miner's Delight +](https://www.curseforge.com/minecraft/mc-mods/miners-delight-plus) | 1.2.3 | Partial Support |
+| [Mo' Creatures Extended](https://www.curseforge.com/minecraft/mc-mods/mo-creatures-extended) | 12.3.2 | Ores Only |
 | [More Buckets](https://modrinth.com/mod/more-buckets) | | Partial Support | # Someone Should return to this
 | [More Slabs Stairs & Walls](https://modrinth.com/mod/more-slabs-stairs-and-walls) | | In Testing | # A lot of these blocks were added before the partial block ID's were added and needs to be fixed.
 | [MoreOres+](https://modrinth.com/mod/moreores+) | | Partial Support |
@@ -202,12 +203,14 @@ Here we can keep track of what mods has been added and what version a contributo
 | [Naturalist](https://modrinth.com/mod/naturalist) | 4.0.3 | Fully Added |
 | [Nature's Spirit](https://modrinth.com/mod/natures-spirit) | | Foliage Only |
 | [Neapolitan](https://www.curseforge.com/minecraft/mc-mods/neapolitan) | 5.0.0 | Foliage Only |
+| [Netherending Ores](https://www.curseforge.com/minecraft/mc-mods/netherending-ores) | 1.4.2 | Fully Added |
+| [Nether Archives](https://modrinth.com/mod/nether-archives) | 0.3.6 | Fully Added |
 | [Nether's Delight](https://modrinth.com/mod/nethers-delight) | | In Testing | # Why is soil in the Deepslate Diamond Ore ID??
-| [Nether Archives](https://modrinth.com/mod/nether-archives) | 0.3.6| Fully Added |
 | [Occultism](https://modrinth.com/mod/occultism) | | Miniscule |
 | [Oh The Biomes We've Gone](https://modrinth.com/mod/oh-the-biomes-weve-gone) | 1.3.0 | Foliage Only |
 | [Oh The Biomes You'll Go](https://modrinth.com/mod/biomesyougo) | | Partial Support |
 | [Ore Creeper](https://modrinth.com/mod/ore-creeper) | | Fully Added |
+| [Oreberries](https://www.curseforge.com/minecraft/mc-mods/oreberries) | 0.5.0 | Fully Added |
 | [Oreganized](https://modrinth.com/mod/oreganized) | | Miniscule |
 | [Organics](https://www.curseforge.com/minecraft/mc-mods/organics) | | Miniscule |
 | [Pam's HarvestCraft 2 - Trees](https://www.curseforge.com/minecraft/mc-mods/pams-harvestcraft-2-trees) | | Fully Added |
@@ -237,10 +240,11 @@ Here we can keep track of what mods has been added and what version a contributo
 | [Serene Shrubbery](https://modrinth.com/mod/serene-shrubbery) | 1.5.1 | Fully Added |
 | [Silent Gear](https://modrinth.com/mod/silent-gear) | | Miniscule |
 | [Silent's Gems](https://modrinth.com/mod/silents-gems) | | Miniscule |
+| [Simple Gravel Ores](https://modrinth.com/mod/simple-gravel-ores) | 1.8 | Fully Added |
 | [Simply Light](https://www.curseforge.com/minecraft/mc-mods/simply-light) | 1.4.6 | Miniscule |
 | [Sky Arena](https://www.curseforge.com/minecraft/mc-mods/sky-arena) | 1.0.0 | Fully Added |
 | [Snowy Spirit](https://modrinth.com/mod/snowy-spirit) | | Foliage Only |
-| [SoulsWeapons](https://modrinth.com/mod/mariums-soulslike-weaponry) | 1.2 |Partial Support | #Added Ore Glowing
+| [SoulsWeapons](https://modrinth.com/mod/mariums-soulslike-weaponry) | 1.2 | Partial Support | #Added Ore Glowing
 | [Spelunker's Charm II](https://modrinth.com/mod/spelunkers-charm-ii) | 3.6.0 | Partial Support |
 | [Spelunkery](https://modrinth.com/mod/spelunkery) | | Fully Added |
 | [Streams] (https://www.curseforge.com/minecraft/mc-mods/streams) | 0.4.9 | Fullly Added |
@@ -252,6 +256,7 @@ Here we can keep track of what mods has been added and what version a contributo
 | [TechReborn](https://www.curseforge.com/minecraft/mc-mods/techreborn) | 5.8.7 | Fully Added | #basically added full support, only thing missing is items glowing and what not, but is not rly needed
 | [Theurgy](https://www.curseforge.com/minecraft/mc-mods/theurgy) | | Fully Added |
 | [Thermal Expansion](https://modrinth.com/mod/thermal-expansion) | | Miniscule |
+| [Thermal Foundation](https://www.curseforge.com/minecraft/mc-mods/thermal-foundation) | 2.6.7.1 | Ores Only |
 | [Thermal: Extra](https://modrinth.com/mod/thermal-extra) | | Miniscule |
 | [Thin Air](https://www.curseforge.com/minecraft/mc-mods/new-thin-air) | | Fullly Added | #It was only one lantern
 | [Things](https://www.curseforge.com/minecraft/mc-mods/things-fabric) | 0.3.3 | Partial | #Ores are glowing now 
@@ -289,7 +294,8 @@ Here we can keep track of what mods has been added and what version a contributo
 - Miniscule: A very small portion of the mod's content has been added or reviewed.
 - Foliage Only: Self-explanatory, only plants, flowers, vines, and other various plantlife has been added.
 - Items Only: Only includes item.properties entries.
-- Entities Only: Only includes entity.properties entries
+- Entities Only: Only includes entity.properties entries.
+- Ores Only: Only Ores have been added to block.properties.
 - Autogenerated Content: This mod contains content that is auto-generated and the blocks that exist will change per modlist. Typically we'll try and support as many of said blocks as possible or use tags where applicable (Iris exclusive feature), however it is most likely you'll need to add blocks yourself. If you're going to use this tag, please explain what is being autogenerated and why in a comment.
 - Unknown: Unable to make a determination of how well a mod has been added due to various factors. Please leave a comment if you're gonna use this status!
 

--- a/block.properties
+++ b/block.properties
@@ -932,7 +932,13 @@ eldritch_end:etyr_ore \
 \
 securitycraft:quartz_mine securitycraft:nether_gold_mine securitycraft:ancient_debris_mine \
 \
-caverns_and_chasms:silver_ore caverns_and_chasms:deepslate_silver_ore caverns_and_chasms:soul_silver_ore caverns_and_chasms:spinel_ore caverns_and_chasms:deepslate_spinel_ore
+caverns_and_chasms:silver_ore caverns_and_chasms:deepslate_silver_ore caverns_and_chasms:soul_silver_ore caverns_and_chasms:spinel_ore caverns_and_chasms:deepslate_spinel_ore \
+\
+thermalfoundation:ore:1 thermalfoundation:ore:2 thermalfoundation:ore:4 thermalfoundation:ore:5 thermalfoundation:ore:7 thermalfoundation:ore:3 \
+\
+netherendingores:ore_other_1:8 netherendingores:ore_other_1:10 \
+\
+gravelores:nickel_gravel_ore gravelores:silver_gravel_ore gravelores:tin_gravel_ore gravelores:lead_gravel_ore 
 
 # Short Foliage / Foliage Lower Half - No Subsurface Scattering
 block.10025 =
@@ -956,7 +962,9 @@ bigreactors:benitoite_ore \
 \
 techreborn:sphalerite_ore techreborn:pyrite_ore techreborn:cinnabar_ore \
 \
-railcraft:firestone_ore
+railcraft:firestone_ore \
+\
+netherendingores:ore_nether_modded_1:0 netherendingores:ore_nether_modded_1:1 netherendingores:ore_nether_modded_1:2 netherendingores:ore_nether_modded_1:3 netherendingores:ore_nether_modded_1:4 netherendingores:ore_nether_modded_1:5 netherendingores:ore_nether_modded_1:6 netherendingores:ore_nether_modded_1:7 netherendingores:ore_nether_modded_1:8 netherendingores:ore_nether_modded_1:9 netherendingores:ore_nether_modded_1:10 netherendingores:ore_nether_modded_1:11 netherendingores:ore_nether_modded_1:12 netherendingores:ore_nether_modded_1:13 netherendingores:ore_nether_modded_1:14 netherendingores:ore_nether_modded_2:0 netherendingores:ore_nether_modded_2:1 netherendingores:ore_nether_modded_2:2 netherendingores:ore_nether_modded_2:3 netherendingores:ore_nether_modded_2:4 netherendingores:ore_nether_modded_2:5 netherendingores:ore_nether_modded_2:6 netherendingores:ore_nether_modded_2:7 netherendingores:ore_nether_modded_2:9 netherendingores:ore_nether_vanilla:1 netherendingores:ore_nether_vanilla:2 netherendingores:ore_nether_vanilla:3 netherendingores:ore_nether_vanilla:4 netherendingores:ore_nether_vanilla:5 netherendingores:ore_nether_vanilla:6
 
 # Tall Foliage / Foliage Upper Half - No Subsurface Scattering
 block.10027 =
@@ -980,10 +988,16 @@ bigreactors:anglesite_ore \
 \
 silentgear:azure_silver_ore \
 \
-techreborn:peridot_ore techreborn:tungsten_ore techreborn:sheldonite_ore techreborn:sodalite_ore
+techreborn:peridot_ore techreborn:tungsten_ore techreborn:sheldonite_ore techreborn:sodalite_ore \
+\
+thermalfoundation:ore_fluid:4 \
+\
+netherendingores:ore_end_modded_1:0 netherendingores:ore_end_modded_1:1 netherendingores:ore_end_modded_1:2 netherendingores:ore_end_modded_1:3 netherendingores:ore_end_modded_1:4 netherendingores:ore_end_modded_1:5 netherendingores:ore_end_modded_1:6 netherendingores:ore_end_modded_1:7 netherendingores:ore_end_modded_1:8 netherendingores:ore_end_modded_1:9 netherendingores:ore_end_modded_1:10 netherendingores:ore_end_modded_1:11 netherendingores:ore_end_modded_1:12 netherendingores:ore_end_modded_1:13 netherendingores:ore_end_modded_1:14 netherendingores:ore_end_modded_2:0 netherendingores:ore_end_modded_2:1 netherendingores:ore_end_modded_2:2 netherendingores:ore_end_modded_2:3 netherendingores:ore_end_modded_2:4 netherendingores:ore_end_modded_2:5 netherendingores:ore_end_modded_2:6 netherendingores:ore_end_modded_2:7 netherendingores:ore_end_modded_2:9 netherendingores:ore_end_vanilla:1 netherendingores:ore_end_vanilla:2 netherendingores:ore_end_vanilla:3 netherendingores:ore_end_vanilla:4 netherendingores:ore_end_vanilla:5 netherendingores:ore_end_vanilla:6 netherendingores:ore_other_1:3 \
+\
+quark:biotite_ore
 
 # Crimson Roots - Better Color balance for Soul Sand Valley Overhaul
-block.10029=crimson_roots \
+block.10029 = crimson_roots \
 \
 chipped:flowered_crimson_roots chipped:sprouting_crimson_roots_bulb chipped:sprouting_crimson_roots chipped:wilted_crimson_roots_bud chipped:wilted_crimson_roots_bulb chipped:budding_crimson_roots_bulb chipped:budding_crimson_roots chipped:crimson_roots_bloom chipped:crimson_roots_bramble chipped:crimson_roots_bud chipped:crimson_roots_bulb chipped:crimson_roots_floret chipped:flowered_crimson_roots_bulb chipped:small_crimson_roots_bud
 
@@ -1501,7 +1515,9 @@ wilderwild:mossy_mud_brick_stairs wilderwild:mossy_mud_brick_slab wilderwild:mos
 
 # The following are before 1.13 variants
 
-block.10080 = stone:variant=stone monster_egg:variant=stone
+block.10080 = stone:variant=stone monster_egg:variant=stone \
+\
+netherendingores:ore_other_1:9
 
 block.10081 = stone_pressure_plate stone_slab:variant=stone double_stone_slab:variant=stone
 
@@ -1838,7 +1854,9 @@ biomesoplenty:flesh biomesoplenty:porous_flesh \
 \
 ad_astra:sky_stone \
 \
-securitycraft:netherrack_mine securitycraft:reinforced_netherrack
+securitycraft:netherrack_mine securitycraft:reinforced_netherrack \
+\
+netherendingores:ore_nether_modded_1:15 netherendingores:ore_nether_modded_2:8 netherendingores:ore_nether_vanilla:0 netherendingores:block_nether_netherfish
 
 # Netherrack Non-Full Blocks (Modded Only)
 block.10141 = dimdoors:netherrack_fence dimdoors:netherrack_slab dimdoors:netherrack_stairs dimdoors:netherrack_wall \
@@ -2970,9 +2988,14 @@ additionallanterns:normal_sandstone_chain
 #else
 
 # Sand MC 1.12
-block.10232 = sand:variant=sand
+block.10232 = sand:variant=sand \
+\
+thermalfoundation:ore_fluid:0
+
 # Red Sand MC 1.12
-block.10236 = sand:variant=red_sand
+block.10236 = sand:variant=red_sand \
+\
+thermalfoundation:ore_fluid:5
 
 # Sandstone Full Block MC 1.12
 block.10240 = sandstone chiseled_sandstone cut_sandstone smooth_sandstone
@@ -3218,7 +3241,9 @@ securitycraft:reinforced_raw_iron_block
 # Glowing Raw Iron Non-Full Blocks (Modded Only)
 block.10269 = extshape:raw_iron_stairs extshape:raw_iron_slab extshape:raw_iron_vertical_slab extshape:raw_iron_vertical_stairs extshape:raw_iron_quarter_piece extshape:raw_iron_vertical_quarter_piece extshape:raw_iron_wall extshape:raw_iron_fence extshape:raw_iron_fence_gate extshape:raw_iron_button extshape:raw_iron_pressure_plate \
 \
-diagonalfences:extshape/raw_iron_fence
+diagonalfences:extshape/raw_iron_fence \
+\
+oreberries:iron_oreberry_bush oreberries:aluminum_oreberry_bush
 
 # Glowing Ores Iron
 block.10272 = iron_ore \
@@ -3244,7 +3269,13 @@ undergarden:depthrock_iron_ore  \
 \
 ad_astra:moon_iron_ore ad_astra:mars_iron_ore ad_astra:mercury_iron_ore ad_astra:glacio_iron_ore \
 \
-securitycraft:iron_mine
+securitycraft:iron_mine \
+\
+mocreatures:ancient_ore mocreatures:wyvern_iron_ore \
+\
+gravelores:iron_gravel_ore \
+\
+growthcraft:salt_ore
 
 # Deepslate Variant
 block.10276 = deepslate_iron_ore \
@@ -3267,7 +3298,9 @@ alltheores:raw_uranium_block
 # Glowing Raw Copper Blocks Non-Full Blocks (Modded Block)
 block.10281 = extshape:raw_copper_stairs extshape:raw_copper_slab extshape:raw_copper_vertical_slab extshape:raw_copper_vertical_stairs extshape:raw_copper_quarter_piece extshape:raw_copper_vertical_quarter_piece extshape:raw_copper_wall extshape:raw_copper_fence extshape:raw_copper_fence_gate extshape:raw_copper_button extshape:raw_copper_pressure_plate \
 \
-diagonalfences:extshape/raw_copper_fence
+diagonalfences:extshape/raw_copper_fence \
+\
+oreberries:copper_oreberry_bush oreberries:tin_oreberry_bush
 
 # Glowing Ores Copper
 block.10284 = copper_ore \
@@ -3295,7 +3328,11 @@ securitycraft:copper_mine \
 \
 techreborn:bauxite_ore \
 \
-ae2:vibration_chamber:active=true
+ae2:vibration_chamber:active=true \
+\
+gravelores:copper_gravel_ore gravelores:aluminum_gravel_ore \
+\
+thermalfoundation:ore:0
 
 # Deepslate Variant
 block.10288 = deepslate_copper_ore \
@@ -3408,7 +3445,9 @@ securitycraft:reinforced_raw_gold_block
 # Glowing Raw Gold Blocks Non-Full Blocks (Modded Block)
 block.10297 = extshape:raw_gold_stairs extshape:raw_gold_slab extshape:raw_gold_vertical_slab extshape:raw_gold_vertical_stairs extshape:raw_gold_quarter_piece extshape:raw_gold_vertical_quarter_piece extshape:raw_gold_wall extshape:raw_gold_fence extshape:raw_gold_fence_gate extshape:raw_gold_button extshape:raw_gold_pressure_plate \
 \
-diagonalfences:extshape/raw_gold_fence
+diagonalfences:extshape/raw_gold_fence \
+\
+oreberries:gold_oreberry_bush
 
 # Glowing Ores Gold
 block.10300 = gold_ore \
@@ -3454,8 +3493,15 @@ infinite_abyss:golden_topaz_crystal \
 \
 bigreactors:yellorite_ore \
 \
-techreborn:diesel_generator:active=true techreborn:gas_turbine:active=true techreborn:semi_fluid_generator:active=true techreborn:solid_fuel_generator:active=true techreborn:thermal_generator:active=true
-
+techreborn:diesel_generator:active=true techreborn:gas_turbine:active=true techreborn:semi_fluid_generator:active=true techreborn:solid_fuel_generator:active=true techreborn:thermal_generator:active=true \
+\
+mocreatures:wyvern_gold_ore \
+\
+gravelores:gold_gravel_ore \
+\
+tconstruct:ore:type=ardite \
+\
+netherendingores:ore_other_1:2 netherendingores:ore_other_1:6
 
 # Deepslate Gold Ore Variant
 block.10302 = deepslate_gold_ore \
@@ -3493,7 +3539,9 @@ pureores:end_ametrine_ore \
 \
 forbidden_arcanus:runic_deepslate \
 \
-caverns_and_chasms:spinel_ore caverns_and_chasms:deepslate_spinel_ore 
+caverns_and_chasms:spinel_ore caverns_and_chasms:deepslate_spinel_ore \
+\
+netherendingores:ore_other_1:7
 
 # Purple Modded Ores
 block.10306 = mythicmetals:kyber_ore mythicmetals:platinum_ore \
@@ -3520,8 +3568,9 @@ techreborn:dragon_egg_syphon:active=true \
 \
 ae2:mysterious_cube ae2:not_so_mysterious_cube ae2:wireless_access_point:state=has_channel ae2:spatial_pylon:powered_on=true ae2:chest:lights_on=true ae2:condenser ae2:crystal_resonance_generator \
 \
-extendedae:wireless_connect:connected=true extendedae:ex_molecular_assembler extendedae:ex_charger
-
+extendedae:wireless_connect:connected=true extendedae:ex_molecular_assembler extendedae:ex_charger \
+\
+netherendingores:ore_other_1:8
 
 # Glowing Ores Nether Gold
 block.10308 = nether_gold_ore \
@@ -3540,7 +3589,9 @@ malum:blazing_quartz_ore \
 \
 ad_astra:venus_gold_ore \
 \
-securitycraft:nether_gold_mine
+securitycraft:nether_gold_mine \
+\
+thermalfoundation:ore_fluid:3
 
 # Gold Blocks
 block.10312 = gold_block \
@@ -3722,7 +3773,14 @@ aquamirae:frozen_chest \
 ae2:quantum_link:formed=true ae2:cell_workbench ae2:dense_energy_cell ae2:energy_cell ae2:1k_crafting_storage:formed=true:powered=true ae2:4k_crafting_storage:powered=true:formed=true ae2:16k_crafting_storage:powered=true:formed=true ae2:64k_crafting_storage:powered=true:formed=true ae2:256k_crafting_storage:powered=true:formed=true ae2:crafting_unit:powered=true:formed=true ae2:crafting_accelerator:powered=true:formed=true \
 \
 megacells:mega_energy_cell:fullness=1 megacells:mega_energy_cell:fullness=2 megacells:mega_energy_cell:fullness=3 megacells:mega_energy_cell:fullness=4 megacells:mega_crafting_unit:powered=true:formed=true megacells:mega_crafting_accelerator:powered=true:formed=true \
-createmetallurgy:light_blue_light_bulb:level=15 createmetallurgy:light_blue_light_bulb:level=14 createmetallurgy:light_blue_light_bulb:level=13 createmetallurgy:light_blue_light_bulb:level=12 createmetallurgy:light_blue_light_bulb:level=11 createmetallurgy:light_blue_light_bulb:level=10 createmetallurgy:light_blue_light_bulb:level=9 createmetallurgy:light_blue_light_bulb:level=8 createmetallurgy:light_blue_light_bulb:level=7 createmetallurgy:light_blue_light_bulb:level=6 createmetallurgy:light_blue_light_bulb:level=5 createmetallurgy:light_blue_light_bulb:level=4 createmetallurgy:light_blue_light_bulb:level=3 createmetallurgy:light_blue_light_bulb:level=2 createmetallurgy:light_blue_light_bulb:level=1 createmetallurgy:blue_light_bulb:level=15 createmetallurgy:blue_light_bulb:level=14 createmetallurgy:blue_light_bulb:level=13 createmetallurgy:blue_light_bulb:level=12 createmetallurgy:blue_light_bulb:level=11 createmetallurgy:blue_light_bulb:level=10 createmetallurgy:blue_light_bulb:level=9 createmetallurgy:blue_light_bulb:level=8 createmetallurgy:blue_light_bulb:level=7 createmetallurgy:blue_light_bulb:level=6 createmetallurgy:blue_light_bulb:level=5 createmetallurgy:blue_light_bulb:level=4 createmetallurgy:blue_light_bulb:level=3 createmetallurgy:blue_light_bulb:level=2 createmetallurgy:blue_light_bulb:level=1
+\
+createmetallurgy:light_blue_light_bulb:level=15 createmetallurgy:light_blue_light_bulb:level=14 createmetallurgy:light_blue_light_bulb:level=13 createmetallurgy:light_blue_light_bulb:level=12 createmetallurgy:light_blue_light_bulb:level=11 createmetallurgy:light_blue_light_bulb:level=10 createmetallurgy:light_blue_light_bulb:level=9 createmetallurgy:light_blue_light_bulb:level=8 createmetallurgy:light_blue_light_bulb:level=7 createmetallurgy:light_blue_light_bulb:level=6 createmetallurgy:light_blue_light_bulb:level=5 createmetallurgy:light_blue_light_bulb:level=4 createmetallurgy:light_blue_light_bulb:level=3 createmetallurgy:light_blue_light_bulb:level=2 createmetallurgy:light_blue_light_bulb:level=1 createmetallurgy:blue_light_bulb:level=15 createmetallurgy:blue_light_bulb:level=14 createmetallurgy:blue_light_bulb:level=13 createmetallurgy:blue_light_bulb:level=12 createmetallurgy:blue_light_bulb:level=11 createmetallurgy:blue_light_bulb:level=10 createmetallurgy:blue_light_bulb:level=9 createmetallurgy:blue_light_bulb:level=8 createmetallurgy:blue_light_bulb:level=7 createmetallurgy:blue_light_bulb:level=6 createmetallurgy:blue_light_bulb:level=5 createmetallurgy:blue_light_bulb:level=4 createmetallurgy:blue_light_bulb:level=3 createmetallurgy:blue_light_bulb:level=2 createmetallurgy:blue_light_bulb:level=1 \
+\
+mocreatures:wyvern_diamond_ore \
+\
+gravelores:diamond_gravel_ore \
+\
+thermalfoundation:ore:6 thermalfoundation:ore:8
 
 # Deepslate Diamond Variant
 block.10324 = deepslate_diamond_ore \
@@ -3916,6 +3974,7 @@ xycraft_world:xychorium_ore_stone_green xycraft_world:xychorium_ore_kivi_green \
 ae2:crafting_monitor:powered=true:formed=true \
 \
 megacells:mega_crafting_monitor:powered=true:formed=true megacells:1m_crafting_storage megacells:4m_crafting_storage megacells:16m_crafting_storage megacells:64m_crafting_storage megacells:256m_crafting_storage \
+\
 createmetallurgy:lime_light_bulb:level=15 createmetallurgy:lime_light_bulb:level=14 createmetallurgy:lime_light_bulb:level=13 createmetallurgy:lime_light_bulb:level=12 createmetallurgy:lime_light_bulb:level=11 createmetallurgy:lime_light_bulb:level=10 createmetallurgy:lime_light_bulb:level=9 createmetallurgy:lime_light_bulb:level=8 createmetallurgy:lime_light_bulb:level=7 createmetallurgy:lime_light_bulb:level=6 createmetallurgy:lime_light_bulb:level=5 createmetallurgy:lime_light_bulb:level=4 createmetallurgy:lime_light_bulb:level=3 createmetallurgy:lime_light_bulb:level=2 createmetallurgy:lime_light_bulb:level=1 createmetallurgy:green_light_bulb:level=15 createmetallurgy:green_light_bulb:level=14 createmetallurgy:green_light_bulb:level=13 createmetallurgy:green_light_bulb:level=12 createmetallurgy:green_light_bulb:level=11 createmetallurgy:green_light_bulb:level=10 createmetallurgy:green_light_bulb:level=9 createmetallurgy:green_light_bulb:level=8 createmetallurgy:green_light_bulb:level=7 createmetallurgy:green_light_bulb:level=6 createmetallurgy:green_light_bulb:level=5 createmetallurgy:green_light_bulb:level=4 createmetallurgy:green_light_bulb:level=3 createmetallurgy:green_light_bulb:level=2 createmetallurgy:green_light_bulb:level=1 \
 \
 scguns:plasma_lantern \
@@ -3924,7 +3983,14 @@ thinair:safety_lantern:air_quality=green \
 \
 chipped:small_green_lantern \
 \
-rsgauges:industrial_green_led:power=true rsgauges:industrial_green_blinking_led:power=true
+rsgauges:industrial_green_led:power=true rsgauges:industrial_green_blinking_led:power=true \
+\
+mocreatures:wyvern_emerald_ore \
+\
+gravelores:emerald_gravel_ore
+
+# Glowing Non-Full Emerald Ore (Modded Only)
+block.10341 = oreberries:essence_oreberry_bush
 
 # Deepslate Variant
 block.10344 = deepslate_emerald_ore \
@@ -4036,7 +4102,15 @@ ae2:quantum_ring:formed=true ae2:spatial_io_port:powered=true ae2:io_port:powere
 \
 extendedae:ex_io_port:powered=true extendedae:crystal_fixer:powered=true extendedae:fishbig \
 \
-createmetallurgy:black_light_bulb:level=15 createmetallurgy:black_light_bulb:level=14 createmetallurgy:black_light_bulb:level=13 createmetallurgy:black_light_bulb:level=12 createmetallurgy:black_light_bulb:level=11 createmetallurgy:black_light_bulb:level=10 createmetallurgy:black_light_bulb:level=9 createmetallurgy:black_light_bulb:level=8 createmetallurgy:black_light_bulb:level=7 createmetallurgy:black_light_bulb:level=6 createmetallurgy:black_light_bulb:level=5 createmetallurgy:black_light_bulb:level=4 createmetallurgy:black_light_bulb:level=3 createmetallurgy:black_light_bulb:level=2 createmetallurgy:black_light_bulb:level=1
+createmetallurgy:black_light_bulb:level=15 createmetallurgy:black_light_bulb:level=14 createmetallurgy:black_light_bulb:level=13 createmetallurgy:black_light_bulb:level=12 createmetallurgy:black_light_bulb:level=11 createmetallurgy:black_light_bulb:level=10 createmetallurgy:black_light_bulb:level=9 createmetallurgy:black_light_bulb:level=8 createmetallurgy:black_light_bulb:level=7 createmetallurgy:black_light_bulb:level=6 createmetallurgy:black_light_bulb:level=5 createmetallurgy:black_light_bulb:level=4 createmetallurgy:black_light_bulb:level=3 createmetallurgy:black_light_bulb:level=2 createmetallurgy:black_light_bulb:level=1 \
+\
+mocreatures:wyvern_lapis_ore \
+\
+gravelores:lapis_gravel_ore \
+\
+tconstruct:ore:type=cobalt \
+\
+netherendingores:ore_other_1:4 netherendingores:ore_other_1:5
 
 # Deepslate Variant
 block.10360 = deepslate_lapis_ore \
@@ -4170,6 +4244,8 @@ alltheores:other_quartz_ore \
 infinite_abyss:opal_ore infinite_abyss:deepsilver_ore infinite_abyss:cursed_opal_ore \
 \
 techreborn:silver_ore techreborn:deepslate_silver_ore techreborn:iridium_ore techreborn:deepslate_iridium_ore techreborn:deepslate_sheldonite_ore \
+\
+netherendingores:ore_other_1:0
 
 # Obsidian Full Blocks
 block.10372 = obsidian \
@@ -4551,7 +4627,9 @@ immersive_weathering:cracked_end_stone_bricks \
 \
 biomesoplenty:algal_end_stone biomesoplenty:unmapped_end_stone biomesoplenty:null_end_stone \
 \
-securitycraft:end_stone_mine securitycraft:reinforced_end_stone securitycraft:reinforced_end_stone_bricks
+securitycraft:end_stone_mine securitycraft:reinforced_end_stone securitycraft:reinforced_end_stone_bricks \
+\
+netherendingores:ore_end_modded_1:15 netherendingores:ore_end_modded_2:8 netherendingores:ore_end_vanilla:0 netherendingores:ore_other_1:1 netherendingores:block_end_endermite
 
 # Endstone Non-Full Blocks
 block.10429 = end_stone_brick_wall end_stone_brick_stairs end_stone_brick_slab \
@@ -5494,10 +5572,14 @@ techreborn:iron_furnace:active=true techreborn:electric_furnace:active=true tech
 #else
 
 # Redstone Ore Unlit mcversion < 1.13
-block.10612 = redstone_ore
+block.10612 = redstone_ore \
+\
+gravelores:redstone_gravel_ore
 #
 # Redstone Ore Lit mcversion < 1.13
-block.10616 = lit_redstone_ore
+block.10616 = lit_redstone_ore \
+\
+thermalfoundation:ore_fluid:2
 #endif
 
 # Deepslate Redstone Ore Unlit
@@ -5527,12 +5609,16 @@ things:deepslate_gleaming_ore
 # Cave Vines Berries False
 block.10629 = cave_vines_plant:berries=false cave_vines:berries=false \
 \
-deeperdarker:glowing_vines_plant:berries=false
+deeperdarker:glowing_vines_plant:berries=false \
+\
+quark:roots quark:roots_blue_flower quark:roots_black_flower quark:roots_white_flower
 
 # Cave Vines Berries True
 block.10632 = cave_vines_plant:berries=true cave_vines:berries=true \
 \
-deeperdarker:glowing_vines_plant:berries=true
+deeperdarker:glowing_vines_plant:berries=true \
+\
+pvj:flouropore
 
 #if MC_VERSION >= 11300
 # Redstone Lamp Unlit
@@ -6024,7 +6110,9 @@ biomesoplenty:dried_salt \
 \
 tconstruct:grout tconstruct:nether_grout \
 \
-securitycraft:gravel_mine securitycraft:suspicious_gravel_mine securitycraft:reinforced_gravel
+securitycraft:gravel_mine securitycraft:suspicious_gravel_mine securitycraft:reinforced_gravel \
+\
+thermalfoundation:ore_fluid:1 gravelores:coal_gravel_ore
 
 # Gravel Non-Full Blocks (Modded Only)
 block.10725 = dimdoors:gravel_fence dimdoors:gravel_button dimdoors:gravel_slab dimdoors:gravel_stairs dimdoors:gravel_wall \

--- a/item.properties
+++ b/item.properties
@@ -990,7 +990,9 @@ create_enchantment_industry:hyper_experience_bottle \
 \
 tide:glowfish \
 \
-aquamirae:ship_graveyard_echo
+aquamirae:ship_graveyard_echo \
+\
+oreberries:essence_oreberry
 
 # Glowing Arrows
 item.45048 = fire_charge spectral_arrow \


### PR DESCRIPTION
Good to document that apparently some mods in the 1.12.2 and before era will crash when Optifine tries to access their block properties, resulting in a out of bounds index fatal crash. must use block's subid.
I.E. thermalfoundation:ore:**0**