### PR TITLE
Fix 1.7.10 Compatibility by converting entries to use meta values.

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -9166,7 +9166,7 @@ natura:bluebells_flower \
 twilightforest:thorn_rose
 
 # Short Foliage / Foliage Lower Half
-block.10005 = double_plant:half=lower tallgrass sapling deadbush wheat carrots potatoes beetroots pumpkin_stem melon_stem \
+block.10005 = double_plant:0 double_plant:1 double_plant:2 double_plant:3 double_plant:4 double_plant:5 tallgrass sapling deadbush wheat carrots potatoes beetroots pumpkin_stem melon_stem \
 \
 farmersdelight:cabbages farmersdelight:tomatoes farmersdelight:onions farmersdelight:wild_cabbages farmersdelight:wild_onions farmersdelight:wild_tomatoes farmersdelight:wild_carrots farmersdelight:wild_potatoes farmersdelight:wild_beetroots \
 \
@@ -9199,7 +9199,7 @@ traverse:cold_grass traverse:dead_grass traverse:orange_autumnal_sapling travers
 twilightforest:twilight_sapling twilightforest:twilight_plant:3 twilightforest:twilight_plant:5 twilightforest:twilight_plant:6
 
 # Leaves - Not affected by Euphoria Patches Seasons (Don't tint in Autumn, get snow in winter)
-block.10007 = leaves:variant=spruce leaves:variant=jungle leaves2:variant=acacia \
+block.10007 = leaves:1 leaves:5 leaves:13 leaves:3 leaves:7 leaves:15 leaves2:0 leaves2:4 leaves2:12 \
 \
 tconstruct:slime_leaves \
 \
@@ -9214,7 +9214,7 @@ traverse:red_autumnal_leaves traverse:brown_autumnal_leaves traverse:orange_autu
 mocreatures:wyvwood_leaves
 
 # Leaves
-block.10009 = leaves:0 leaves2:0 leaves:variant=oak leaves:variant=birch leaves2:variant=dark_oak \
+block.10009 = leaves:0 leaves:4 leaves:12 leaves:2 leaves:6 leaves:14 leaves2:1 leaves2:5 leaves2:13 \
 \
 traverse:fir_leaves \
 \
@@ -9276,7 +9276,7 @@ twilightforest:block_storage:2 twilightforest:hedge twilightforest:twilight_plan
 block.10019 = pvj:flower_patch
 
 # Tall Foliage Upper Half
-block.10021 = double_plant:half=upper pvj:cattail:half=upper pvj:sea_oats:half=upper
+block.10021 = double_plant:8 double_plant:9 double_plant:10 double_plant:11 pvj:cattail:half=upper pvj:sea_oats:half=upper
 
 # Tall Flowers Upper half - Euphoria Patches Emissive Flowers
 block.10023 =
@@ -9308,7 +9308,7 @@ quark:biotite_ore
 block.10029 =
 
 # Stone Bricks
-block.10032 = stonebrick monster_egg:variant=stone_brick monster_egg:variant=mossy_brick monster_egg:variant=cracked_brick monster_egg:variant=chiseled_brick \
+block.10032 = stonebrick monster_egg:2 monster_egg:3 monster_egg:4 monster_egg:5 double_stone_slab:5 \
 \
 ancientbeasts:pokey \
 \
@@ -9327,7 +9327,7 @@ traverse:blue_rock_bricks traverse:blue_rock_bricks_chiseled traverse:blue_rock_
 twilightforest:etched_nagastone twilightforest:etched_nagastone_mossy twilightforest:etched_nagastone_weathered twilightforest:naga_stone twilightforest:nagastone_pillar twilightforest:nagastone_pillar_mossy twilightforest:nagastone_pillar_weathered twilightforest:stone_twist twilightforest:stronghold_shield
 
 # Stone Brick Slabs and Stairs
-block.10033 = stone_slab:variant=stone_brick double_stone_slab:variant=stone_brick stone_brick_stairs \
+block.10033 = stone_slab:5 stone_slab:13 stone_brick_stairs \
 \
 tconstruct:stone_ladder \
 \
@@ -9354,7 +9354,7 @@ natura:blaze_rail natura:blaze_rail_activator natura:blaze_rail_detector natura:
 
 
 # Cauldron / Unlocked Hopper
-block.10045 = cauldron:level=0 hopper:enabled=true \
+block.10045 = cauldron:0 hopper:0 hopper:2 hopper:3 hopper:4 hopper:5 \
 \
 growthcraft_cellar:brew_kettle \
 \
@@ -9367,10 +9367,10 @@ placeableitems:block_empty_bucket placeableitems:block_milk_bucket \
 xreliquary:apothecary_cauldron:level=0
 
 # Locked Hopper - Euphoria Patches Redstone IPBR
-block.10047 = hopper:enabled=false
+block.10047 = hopper:8 hopper:10 hopper:11 hopper:12 hopper:13
 
 # Cauldron With Water
-block.10049 = cauldron:level=1 cauldron:level=2 cauldron:level=3 \
+block.10049 = cauldron:1 cauldron:2 cauldron:3 \
 \
 nyx:lunar_water_cauldron \
 \
@@ -9411,7 +9411,7 @@ block.10076 =
 
 
 # Stone Full Blocks
-block.10080 = stone:variant=stone monster_egg:variant=stone coal_ore \
+block.10080 = stone:0 monster_egg:0 coal_ore double_stone_slab:0 \
 \
 netherendingores:ore_other_1:9 \
 \
@@ -9426,7 +9426,7 @@ xreliquary:apothecary_mortar \
 twilightforest:deadrock twilightforest:maze_stone twilightforest:trollsteinn
 
 # Stone Non-Full Blocks
-block.10081 = stone_pressure_plate:powered=false stone_button:powered=false stone_slab:variant=stone double_stone_slab:variant=stone \
+block.10081 = stone_pressure_plate:0 stone_button:0 stone_button:1 stone_button:2 stone_button:3 stone_button:4 stone_button:5 stone_slab:0 stone_slab:8 \
 \
 mod_lavacow:tombstone \
 \
@@ -9439,10 +9439,10 @@ quark:polished_stone quark:stone_speleothem quark:stone_stairs quark:stone_wall 
 twilightforest:trophy_pedestal
 
 # Enabled Redstone Stone Blocks - Euphoria Patches Redstone IPBR
-block.10083 = stone_pressure_plate:powered=true stone_button:powered=true
+block.10083 = stone_pressure_plate:1 stone_button:8 stone_button:9 stone_button:10 stone_button:11 stone_button:12 stone_button:13
 
 # Granite Full Block
-block.10084 = stone:variant=granite \
+block.10084 = stone:1 \
 \
 pvj:granite_rocks \
 \
@@ -9452,7 +9452,7 @@ quark:jasper_speleothem quark:jasper_wall quark:stone_granite_slab quark:stone_g
 block.10085 =
 
 # Diorite Full Block
-block.10088 = stone:variant=diorite \
+block.10088 = stone:3 \
 \
 pvj:diorite_rocks pvj:limestone pvj:limestone_double_slab pvj:limestone_slab pvj:limestone_stairs pvj:marble pvj:marble_double_slab pvj:marble_slab pvj:marble_stairs \
 \
@@ -9462,7 +9462,7 @@ quark:diorite_speleothem quark:limestone quark:limestone_speleothem quark:limest
 block.10089 =
 
 # Andesite Full Block
-block.10092 = stone:variant=andesite \
+block.10092 = stone:5 \
 \
 cqrepoured:andesite_carved cqrepoured:andesite_cube cqrepoured:andesite_large cqrepoured:andesite_pillar cqrepoured:andesite_scale cqrepoured:andesite_small cqrepoured:andesite_square \
 \
@@ -9476,7 +9476,7 @@ quark:andesite_speleothem quark:stone_andesite_slab_double quark:stone_andesite_
 block.10093 =
 
 # Polished Granite Full Block
-block.10096 = stone:variant=smooth_granite \
+block.10096 = stone:2 \
 \
 chisel:granite chisel:granite1 chisel:granite2 \
 \
@@ -9488,7 +9488,7 @@ quark:granite_speleothem quark:world_stone_carved:variant=stone_granite_carved q
 block.10097 =
 
 # Polished Diorite Full Block
-block.10100 = stone:variant=smooth_diorite \
+block.10100 = stone:4 \
 \
 chisel:diorite chisel:diorite1 chisel:diorite2 chisel:valentines \
 \
@@ -9502,7 +9502,7 @@ chisel:marble chisel:marble1 chisel:marble2 chisel:marblepillar
 block.10101 =
 
 # Polished Andesite Full Block / Mud Brick Full Block / Bricks
-block.10104 = brick_block stone:variant=smooth_andesite double_stone_slab:variant=brick \
+block.10104 = brick_block stone:6 double_stone_slab:4 \
 \
 ancientbeasts:skewer \
 \
@@ -9513,7 +9513,7 @@ quark:brick_wall quark:world_stone_carved:variant=stone_andesite_carved quark:wo
 twilightforest:underbrick
 
 # Polished Andesite Non-Full Blocks / Mud Brick Non-Full Blocks
-block.10105 = brick_stairs stone_slab:variant=brick \
+block.10105 = brick_stairs stone_slab:4 stone_slab:12 \
 \
 tconstruct:dried_clay:type=brick tconstruct:dried_clay_slab:type=brick tconstruct:dried_brick_stairs tconstruct:deco_ground tconstruct:deco_ground_slab tconstruct:mudbrick_stairs \
 \
@@ -9595,7 +9595,7 @@ natura:nether_tainted_soil:type=tainted_soil \
 tombmanygraves:grave_block
 
 # Farmland Moisture 0-6
-block.10129 = farmland:moisture=0 farmland:moisture=1 farmland:moisture=2 farmland:moisture=3 farmland:moisture=4 farmland:moisture=5 farmland:moisture=6 \
+block.10129 = farmland:0 farmland:1 farmland:2 farmland:3 farmland:4 farmland:5 farmland:6 \
 \
 farmingforblockheads:fertilized_farmland_rich:moisture=1 farmingforblockheads:fertilized_farmland_rich:moisture=2 farmingforblockheads:fertilized_farmland_rich:moisture=3 farmingforblockheads:fertilized_farmland_rich:moisture=4 farmingforblockheads:fertilized_farmland_rich:moisture=5 farmingforblockheads:fertilized_farmland_rich:moisture=6 farmingforblockheads:fertilized_farmland_rich_stable:moisture=0 farmingforblockheads:fertilized_farmland_rich_stable:moisture=1 farmingforblockheads:fertilized_farmland_rich_stable:moisture=2 farmingforblockheads:fertilized_farmland_rich_stable:moisture=3 farmingforblockheads:fertilized_farmland_rich_stable:moisture=4 farmingforblockheads:fertilized_farmland_rich_stable:moisture=5 farmingforblockheads:fertilized_farmland_rich_stable:moisture=6 farmingforblockheads:fertilized_farmland_healthy:moisture=0 farmingforblockheads:fertilized_farmland_healthy:moisture=1 farmingforblockheads:fertilized_farmland_healthy:moisture=2 farmingforblockheads:fertilized_farmland_healthy:moisture=3 farmingforblockheads:fertilized_farmland_healthy:moisture=4 farmingforblockheads:fertilized_farmland_healthy:moisture=5 farmingforblockheads:fertilized_farmland_healthy:moisture=6 farmingforblockheads:fertilized_farmland_healthy_stable:moisture=0 farmingforblockheads:fertilized_farmland_healthy_stable:moisture=1 farmingforblockheads:fertilized_farmland_healthy_stable:moisture=2 farmingforblockheads:fertilized_farmland_healthy_stable:moisture=3 farmingforblockheads:fertilized_farmland_healthy_stable:moisture=4 farmingforblockheads:fertilized_farmland_healthy_stable:moisture=5 farmingforblockheads:fertilized_farmland_healthy_stable:moisture=6 farmingforblockheads:fertilized_farmland_stable:moisture=0 farmingforblockheads:fertilized_farmland_stable:moisture=1 farmingforblockheads:fertilized_farmland_stable:moisture=2 farmingforblockheads:fertilized_farmland_stable:moisture=3 farmingforblockheads:fertilized_farmland_stable:moisture=4 farmingforblockheads:fertilized_farmland_stable:moisture=5 farmingforblockheads:fertilized_farmland_stable:moisture=6 \
 \
@@ -9619,8 +9619,14 @@ block.10133 = natura:colored_grass_slab natura:colored_grass_stairs_autumnal nat
 \
 quark:turf_slab quark:turf_stairs
 
+# Farmland Moisture 7 (Fully Moist)
+block.10137 = farmland:7 \
+\
+farmingforblockheads:fertilized_farmland_rich:moisture=7 farmingforblockheads:fertilized_farmland_rich_stable:moisture=7 farmingforblockheads:fertilized_farmland_healthy:moisture=7 farmingforblockheads:fertilized_farmland_healthy_stable:moisture=7 farmingforblockheads:fertilized_farmland_stable:moisture=7
+
 # Netherrack
 block.10140 = netherrack \
+\
 netherendingores:ore_nether_modded_1:15 netherendingores:ore_nether_modded_2:8 netherendingores:ore_nether_vanilla:0 netherendingores:block_nether_netherfish \
 \
 chisel:netherrack chisel:netherbrick:1 chisel:netherbrick:2 chisel:netherbrick:3 chisel:netherbrick:4 chisel:netherbrick:9 chisel:netherbrick:10 chisel:netherbrick:11 chisel:netherbrick:12 \
@@ -9656,7 +9662,7 @@ block.10150 = nether_wart_block
 block.10151 = piston:8 piston:9 piston:10 piston:11 piston:12 piston:13 sticky_piston:8 sticky_piston:9 sticky_piston:10 sticky_piston:11 sticky_piston:12 sticky_piston:13 piston_head:8 piston_head:9 piston_head:10 piston_head:11 piston_head:12 piston_head:13 dispenser:8 dispenser:9 dispenser:10 dispenser:11 dispenser:12 dispenser:13 dropper:8 dropper:9 dropper:10 dropper:11 dropper:12 dropper:13
 
 # Cobblestone, Piston, Dispeser, Dropper
-block.10152 = cobblestone stone_stairs monster_egg:variant=cobblestone mossy_cobblestone furnace piston:0 piston:1 piston:2 piston:3 piston:4 piston:5 sticky_piston:0 sticky_piston:1 sticky_piston:2 sticky_piston:3 sticky_piston:4 sticky_piston:5 dispenser:0 dispenser:1 dispenser:2 dispenser:3 dispenser:4 dispenser:5 dropper:0 dropper:1 dropper:2 dropper:3 dropper:4 dropper:5 \
+block.10152 = cobblestone stone_stairs monster_egg:1 mossy_cobblestone furnace piston:0 piston:1 piston:2 piston:3 piston:4 piston:5 sticky_piston:0 sticky_piston:1 sticky_piston:2 sticky_piston:3 sticky_piston:4 sticky_piston:5 dispenser:0 dispenser:1 dispenser:2 dispenser:3 dispenser:4 dispenser:5 dropper:0 dropper:1 dropper:2 dropper:3 dropper:4 dropper:5 double_stone_slab:3 \
 \
 quark:jasper \
 \
@@ -9677,7 +9683,7 @@ quark:biome_cobblestone:2 quark:cobbed_stone_slab_double quark:cobblestone_mossy
 twilightforest:cinder_furnace twilightforest:giant_cobblestone
 
 # Cobblestone Non-Full Blocks
-block.10153 = cobblestone_wall piston_head:0 piston_head:1 piston_head:2 piston_head:3 piston_head:4 piston_head:5 stone_slab:variant=cobblestone double_stone_slab:variant=cobblestone \
+block.10153 = cobblestone_wall piston_head:0 piston_head:1 piston_head:2 piston_head:3 piston_head:4 piston_head:5 stone_slab:3 stone_slab:11 \
 \
 growthcraft_cellar:fruit_presser \
 \
@@ -9693,7 +9699,7 @@ block.10155 =
 
 
 # Oak Full Blocks
-block.10156 = planks:variant=oak double_wooden_slab:variant=oak bookshelf crafting_table \
+block.10156 = planks:0 double_wooden_slab:0 bookshelf crafting_table double_stone_slab:2 \
 \
 tconstruct:wood_rail tconstruct:wood_rail_trapdoor tconstruct:wooden_hopper tconstruct:rack \
 \
@@ -9712,7 +9718,7 @@ quark:carved_wood:0 quark:vertical_planks:variant=vertical_oak_planks \
 twilightforest:twilight_oak_planks twilightforest:twilight_oak_doubleslab
 
 # Oak Non-Full Blocks
-block.10157 = trapdoor:open=false wooden_button:powered=false wooden_pressure_plate:powered=false fence_gate:powered=false tripwire_hook:powered=false wooden_slab:variant=oak oak_stairs fence \
+block.10157 = trapdoor:0 trapdoor:1 trapdoor:2 trapdoor:3 trapdoor:8 trapdoor:9 trapdoor:10 trapdoor:11 wooden_button:0 wooden_button:1 wooden_button:2 wooden_button:3 wooden_button:4 wooden_button:5 wooden_pressure_plate:0 fence_gate:0 fence_gate:1 fence_gate:2 fence_gate:3 fence_gate:4 fence_gate:5 fence_gate:6 fence_gate:7 tripwire_hook:0 tripwire_hook:1 tripwire_hook:2 tripwire_hook:3 tripwire_hook:4 tripwire_hook:5 tripwire_hook:6 tripwire_hook:7 wooden_slab:0 wooden_slab:8 oak_stairs fence stone_slab:2 stone_slab:10 \
 \
 tconstruct:tooltables tconstruct:lavawood_stairs \
 \
@@ -9751,10 +9757,10 @@ storagedrawers:framingtable storagedrawers:trim:variant=oak \
 twilightforest:slider
 
 # Oak Powered Blocks - Euphoria Patches Redstone IPBR
-block.10159 = trapdoor:open=true wooden_button:powered=true wooden_pressure_plate:powered=true tripwire_hook:powered=true fence_gate:powered=true
+block.10159 = trapdoor:4 trapdoor:5 trapdoor:6 trapdoor:7 trapdoor:12 trapdoor:13 trapdoor:14 trapdoor:15 wooden_button:8 wooden_button:9 wooden_button:10 wooden_button:11 wooden_button:12 wooden_button:13 wooden_pressure_plate:1 fence_gate:8 fence_gate:9 fence_gate:10 fence_gate:11 fence_gate:12 fence_gate:13 fence_gate:14 fence_gate:15 tripwire_hook:12 tripwire_hook:13 tripwire_hook:14 tripwire_hook:15
 
 # Oak Logs
-block.10160 = log:variant=oak \
+block.10160 = log:0 log:4 log:8 log:12 \
 \
 ancientbeasts:thatch \
 \
@@ -9772,7 +9778,7 @@ block.10161 = chiselsandbits:bittank \
 quark:bark_oak_slab quark:bark_oak_stairs quark:bark_oak_wall
 
 # Spruce Full Blocks
-block.10164 = planks:variant=spruce double_wooden_slab:variant=spruce \
+block.10164 = planks:1 double_wooden_slab:1 \
 \
 chisel:bookshelf_spruce chisel:paper:0 chisel:paper:1 chisel:paper:2 chisel:paper:3 chisel:paper:4 chisel:paper:5 chisel:paper:6 chisel:paper:8 chisel:planks-spruce \
 \
@@ -9788,7 +9794,7 @@ twilightforest:canopy_planks twilightforest:canopy_doubleslab twilightforest:dar
 
 
 # Spruce Non-Full Blocks
-block.10165 = spruce_fence spruce_fence_gate:powered=false wooden_slab:variant=spruce spruce_stairs \
+block.10165 = spruce_fence spruce_fence_gate:0 spruce_fence_gate:1 spruce_fence_gate:2 spruce_fence_gate:3 spruce_fence_gate:4 spruce_fence_gate:5 spruce_fence_gate:6 spruce_fence_gate:7 wooden_slab:1 wooden_slab:9 spruce_stairs \
 \
 twilightforest:time_doubleslab \
 \
@@ -9811,10 +9817,10 @@ quark:spruce_button quark:spruce_pressure_plate quark:spruce_trapdoor \
 twilightforest:canopy_button twilightforest:canopy_door twilightforest:canopy_fence twilightforest:canopy_gate twilightforest:canopy_plate twilightforest:canopy_slab twilightforest:canopy_stairs twilightforest:canopy_trapdoor twilightforest:dark_button twilightforest:dark_door twilightforest:dark_fence twilightforest:dark_gate twilightforest:dark_plate twilightforest:dark_slab twilightforest:dark_stairs twilightforest:dark_trapdoor twilightforest:time_button twilightforest:time_door twilightforest:time_fence twilightforest:time_gate twilightforest:time_plate twilightforest:time_slab twilightforest:time_stairs twilightforest:time_trapdoor
 
 # Spruce Powered Blocks - Euphoria Patches Redstone IPBR
-block.10167 = spruce_fence_gate:powered=true
+block.10167 = spruce_fence_gate:8 spruce_fence_gate:9 spruce_fence_gate:10 spruce_fence_gate:11 spruce_fence_gate:12 spruce_fence_gate:13 spruce_fence_gate:14 spruce_fence_gate:15
 
 # Spruce Logs
-block.10168 = log:variant=spruce \
+block.10168 = log:1 log:5 log:9 log:13 \
 \
 ancientbeasts:stick_wall \
 \
@@ -9832,7 +9838,7 @@ block.10169 = growthcraft_grapes:native_grape_vine1 quark:bark_spruce_slab quark
 twilightforest:thorns
 
 # Birch Full Blocks
-block.10172 = planks:variant=birch double_wooden_slab:variant=birch \
+block.10172 = planks:2 double_wooden_slab:2 \
 \
 chisel:bookshelf_birch chisel:planks-birch \
 \
@@ -9849,7 +9855,7 @@ storagedrawers:trim:variant=birch \
 twilightforest:fire_jet:variant=encased_smoker_off twilightforest:fire_jet:variant=encased_smoker_on twilightforest:mangrove_doubleslab twilightforest:mangrove_planks twilightforest:mangrove_doubleslab twilightforest:mangrove_planks twilightforest:mine_doubleslab twilightforest:mine_planks twilightforest:tower_device twilightforest:tower_wood:1
 
 # Birch Non-Full Blocks
-block.10173 = wooden_slab:variant=birch birch_fence_gate:powered=false birch_fence birch_stairs \
+block.10173 = wooden_slab:2 wooden_slab:10 birch_fence_gate:0 birch_fence_gate:1 birch_fence_gate:2 birch_fence_gate:3 birch_fence_gate:4 birch_fence_gate:5 birch_fence_gate:6 birch_fence_gate:7 birch_fence birch_stairs \
 \
 cqrepoured:table_birch \
 \
@@ -9870,10 +9876,10 @@ treechop:chopped_log_corner_ne treechop:chopped_log_corner_nw treechop:chopped_l
 twilightforest:mangrove_button twilightforest:mangrove_door twilightforest:mangrove_fence twilightforest:mangrove_gate twilightforest:mangrove_plate twilightforest:mangrove_slab twilightforest:mangrove_stairs twilightforest:mangrove_trapdoor twilightforest:mine_button twilightforest:mine_door twilightforest:mine_fence twilightforest:mine_gate twilightforest:mine_plate twilightforest:mine_slab twilightforest:mine_stairs twilightforest:mine_trapdoor
 
 # Birch Powered Blocks - Euphoria Patches Redstone IPBR
-block.10175 = birch_fence_gate:powered=true
+block.10175 = birch_fence_gate:8 birch_fence_gate:9 birch_fence_gate:10 birch_fence_gate:11 birch_fence_gate:12 birch_fence_gate:13 birch_fence_gate:14 birch_fence_gate:15
 
 # Birch Logs
-block.10176 = log:variant=birch \
+block.10176 = log:2 log:6 log:10 log:14 \
 \
 growthcraft_cellar:cork_log \
 \
@@ -9891,7 +9897,7 @@ twilightforest:twilight_log:variant=mangrove twilightforest:magic_log:variant=mi
 block.10177 = quark:bark_birch_slab quark:bark_birch_stairs quark:bark_birch_wall
 
 # Jungle Full Blocks
-block.10180 = planks:variant=jungle double_wooden_slab:variant=jungle \
+block.10180 = planks:3 double_wooden_slab:3 \
 \
 chisel:bookshelf_jungle chisel:planks-jungle \
 \
@@ -9908,7 +9914,7 @@ storagedrawers:trim:variant=jungle \
 twilightforest:uncrafting_table twilightforest:twilight_oak_planks twilightforest:twilight_oak_doubleslab
 
 # Jungle Non-Full Blocks
-block.10181 = wooden_slab:variant=jungle jungle_fence_gate:powered=false jungle_fence jungle_stairs \
+block.10181 = wooden_slab:3 wooden_slab:11 jungle_fence_gate:0 jungle_fence_gate:1 jungle_fence_gate:2 jungle_fence_gate:3 jungle_fence_gate:4 jungle_fence_gate:5 jungle_fence_gate:6 jungle_fence_gate:7 jungle_fence jungle_stairs \
 \
 cqrepoured:table_jungle \
 \
@@ -9927,10 +9933,10 @@ quark:jungle_button quark:jungle_pressure_plate quark:jungle_trapdoor \
 twilightforest:twilight_oak_button twilightforest:twilight_oak_door twilightforest:twilight_oak_fence twilightforest:twilight_oak_gate twilightforest:twilight_oak_plate twilightforest:twilight_oak_slab twilightforest:twilight_oak_stairs twilightforest:twilight_oak_trapdoor
 
 # Jungle Powered Blocks - Euphoria Patches Redstone IPBR
-block.10183 = jungle_fence_gate:powered=true
+block.10183 = jungle_fence_gate:8 jungle_fence_gate:9 jungle_fence_gate:10 jungle_fence_gate:11 jungle_fence_gate:12 jungle_fence_gate:13 jungle_fence_gate:14 jungle_fence_gate:15
 
 # Jungle Logs
-block.10184 = log:variant=jungle \
+block.10184 = log:3 log:7 log:11 log:15 \
 \
 pvj:log_palm \
 \
@@ -9942,7 +9948,7 @@ twilightforest:twilight_log:variant=oak
 block.10185 = quark:bark_jungle_slab quark:bark_jungle_stairs quark:bark_jungle_wall
 
 # Acacia Full Blocks
-block.10188 = planks:variant=acacia double_wooden_slab:variant=acacia \
+block.10188 = planks:4 double_wooden_slab:4 \
 \
 chisel:bookshelf_acacia chisel:planks-acacia \
 \
@@ -9963,7 +9969,7 @@ traverse:fir_planks traverse:fir_double_slab \
 twilightforest:tower_translucent twilightforest:tower_wood:0 twilightforest:tower_wood:2 twilightforest:tower_wood:3 twilightforest:tower_wood:4
 
 # Acacia Non-Full Blocks
-block.10189 = acacia_fence_gate:powered=false wooden_slab:variant=acacia acacia_fence acacia_stairs \
+block.10189 = acacia_fence_gate:0 acacia_fence_gate:1 acacia_fence_gate:2 acacia_fence_gate:3 acacia_fence_gate:4 acacia_fence_gate:5 acacia_fence_gate:6 acacia_fence_gate:7 wooden_slab:4 wooden_slab:12 acacia_fence acacia_stairs \
 \
 cqrepoured:table_acacia \
 \
@@ -9986,10 +9992,10 @@ quark:acacia_button quark:acacia_pressure_plate quark:acacia_trapdoor \
 traverse:fir_door traverse:fir_fence traverse:fir_fence_gate traverse:fir_slab traverse:fir_stairs
 
 # Acacia Powered Blocks - Euphoria Patches Redstone IPBR
-block.10191 = acacia_fence_gate:powered=true
+block.10191 = acacia_fence_gate:8 acacia_fence_gate:9 acacia_fence_gate:10 acacia_fence_gate:11 acacia_fence_gate:12 acacia_fence_gate:13 acacia_fence_gate:14 acacia_fence_gate:15
 
 # Acacia Logs
-block.10192 = log2:variant=acacia \
+block.10192 = log2:0 log2:4 log2:8 log2:12  \
 \
 natura:overworld_logs:type=amaranth natura:redwood_logs \
 \
@@ -10005,7 +10011,7 @@ block.10193 = natura:overworld_door_redwood_bark \
 quark:bark_acacia_slab quark:bark_acacia_stairs quark:bark_acacia_wall
 
 # Dark Oak Full Blocks
-block.10196 = planks:variant=dark_oak double_wooden_slab:variant=dark_oak \
+block.10196 = planks:5 double_wooden_slab:5 \
 \
 chisel:bookshelf_darkoak chisel:planks-dark-oak \
 \
@@ -10022,7 +10028,7 @@ storagedrawers:trim:variant=dark_oak \
 twilightforest:sort_doubleslab twilightforest:sort_planks
 
 # Dark Oak Non-Full Blocks
-block.10197 = dark_oak_fence_gate:powered=false dark_oak_fence dark_oak_stairs wooden_slab:variant=dark_oak \
+block.10197 = dark_oak_fence_gate:0 dark_oak_fence_gate:1 dark_oak_fence_gate:2 dark_oak_fence_gate:3 dark_oak_fence_gate:4 dark_oak_fence_gate:5 dark_oak_fence_gate:6 dark_oak_fence_gate:7 dark_oak_fence dark_oak_stairs wooden_slab:5 wooden_slab:13 \
 \
 cqrepoured:table_dark \
 \
@@ -10043,10 +10049,10 @@ quark:dark_oak_button quark:dark_oak_pressure_plate quark:dark_oak_trapdoor \
 twilightforest:sort_button twilightforest:sort_door twilightforest:sort_fence twilightforest:sort_gate twilightforest:sort_plate twilightforest:sort_slab twilightforest:sort_stairs twilightforest:sort_trapdoor
 
 # Dark Oak Powered Blocks - Euphoria Patches Redstone IPBR
-block.10199 = dark_oak_fence_gate:powered=true
+block.10199 = dark_oak_fence_gate:8 dark_oak_fence_gate:9 dark_oak_fence_gate:10 dark_oak_fence_gate:11 dark_oak_fence_gate:12 dark_oak_fence_gate:13 dark_oak_fence_gate:14 dark_oak_fence_gate:15
 
 # Dark Oak Logs
-block.10200 = log2:variant=dark_oak \
+block.10200 = log2:1 log2:5 log2:9 log2:13 \
 \
 natura:overworld_logs2:type=willow natura:overworld_logs2:type=sakura natura:nether_logs:type=fusewood \
 \
@@ -10129,7 +10135,7 @@ block.10229 =
 
 
 # Sand
-block.10232 = sand:variant=sand \
+block.10232 = sand:0 \
 \
 thermalfoundation:ore_fluid:0 \
 \
@@ -10140,7 +10146,7 @@ mocreatures:silver_sand \
 quark:sugar_block
 
 # Red Sand
-block.10236 = sand:variant=red_sand \
+block.10236 = sand:1 \
 \
 thermalfoundation:ore_fluid:5 \
 \
@@ -10149,7 +10155,7 @@ natura:nether_heat_sand \
 quark:gravisand
 
 # Sandstone Full Block
-block.10240 = sandstone double_stone_slab:variant=sandstone \
+block.10240 = sandstone double_stone_slab:1 \
 \
 chisel:sandstone-scribbles chisel:sandstoneyellow chisel:sandstoneyellow1 chisel:sandstoneyellow2 \
 \
@@ -10168,7 +10174,7 @@ chisel:limestone chisel:limestone1 chisel:limestone2 \
 quark:sandstone_new:variant=sandstone_smooth quark:sandstone_new:variant=sandstone_bricks quark:sandstone_bricks_slab_double quark:sandstone_smooth_slab_double
 
 # Sandstone Non-Full Block
-block.10241 = stone_slab:variant=sandstone sandstone_stairs \
+block.10241 = stone_slab:1 stone_slab:9 sandstone_stairs \
 \
 nyx:star_stairs nyx:star_slab \
 \
@@ -10254,7 +10260,7 @@ twilightforest:block_storage:0
 
 
 # Unpowered Heavy Weighted Pressure Plate - Euphoria Patches Redstone IPBR
-block.10265 = heavy_weighted_pressure_plate:power=0 \
+block.10265 = heavy_weighted_pressure_plate:0 \
 \
 tconstruct:toolforge \
 \
@@ -10279,7 +10285,7 @@ bibliocraft:markerpole bibliocraft:printingpress \
 twilightforest:knightmetal_block
 
 # Powered Heavy Weighted Pressure Plate - Euphoria Patches Redstone IPBR
-block.10267 = heavy_weighted_pressure_plate:power=1 heavy_weighted_pressure_plate:power=2 heavy_weighted_pressure_plate:power=3 heavy_weighted_pressure_plate:power=4 heavy_weighted_pressure_plate:power=5 heavy_weighted_pressure_plate:power=6 heavy_weighted_pressure_plate:power=7 heavy_weighted_pressure_plate:power=8 heavy_weighted_pressure_plate:power=9 heavy_weighted_pressure_plate:power=10 heavy_weighted_pressure_plate:power=11 heavy_weighted_pressure_plate:power=12 heavy_weighted_pressure_plate:power=13 heavy_weighted_pressure_plate:power=14 heavy_weighted_pressure_plate:power=15
+block.10267 = heavy_weighted_pressure_plate:1 heavy_weighted_pressure_plate:2 heavy_weighted_pressure_plate:3 heavy_weighted_pressure_plate:4 heavy_weighted_pressure_plate:5 heavy_weighted_pressure_plate:6 heavy_weighted_pressure_plate:7 heavy_weighted_pressure_plate:8 heavy_weighted_pressure_plate:9 heavy_weighted_pressure_plate:10 heavy_weighted_pressure_plate:11 heavy_weighted_pressure_plate:12 heavy_weighted_pressure_plate:13 heavy_weighted_pressure_plate:14 heavy_weighted_pressure_plate:15
 
 # Euphoria Patches Glowing Raw Iron Blocks
 block.10268 =
@@ -10360,7 +10366,7 @@ chisel:blockelectrum chisel:blockgold chisel:futura:5 chisel:glass1:0 chisel:gla
 thermalfoundation:storage:5 thermalfoundation:storage_alloy:1 thermalfoundation:storage_alloy:6
 
 # Unpowered Light Weighted Pressure Plate - Euphoria Patches Redstone IPBR
-block.10313 = light_weighted_pressure_plate:power=0 \
+block.10313 = light_weighted_pressure_plate:0 \
 \
 dimdoors:gold_door dimdoors:gold_dimensional_door \
 \
@@ -10373,7 +10379,7 @@ placeableitems:block_clock placeableitems:block_melon_glistering placeableitems:
 quark:gold_button
 
 # Powered Light Weighted Pressure Plate - Euphoria Patches Redstone IPBR
-block.10315 = light_weighted_pressure_plate:power=1 light_weighted_pressure_plate:power=2 light_weighted_pressure_plate:power=3 light_weighted_pressure_plate:power=4 light_weighted_pressure_plate:power=5 light_weighted_pressure_plate:power=6 light_weighted_pressure_plate:power=7 light_weighted_pressure_plate:power=8 light_weighted_pressure_plate:power=9 light_weighted_pressure_plate:power=10 light_weighted_pressure_plate:power=11 light_weighted_pressure_plate:power=12 light_weighted_pressure_plate:power=13 light_weighted_pressure_plate:power=14 light_weighted_pressure_plate:power=15
+block.10315 = light_weighted_pressure_plate:1 light_weighted_pressure_plate:2 light_weighted_pressure_plate:3 light_weighted_pressure_plate:4 light_weighted_pressure_plate:5 light_weighted_pressure_plate:6 light_weighted_pressure_plate:7 light_weighted_pressure_plate:8 light_weighted_pressure_plate:9 light_weighted_pressure_plate:10 light_weighted_pressure_plate:11 light_weighted_pressure_plate:12 light_weighted_pressure_plate:13 light_weighted_pressure_plate:14 light_weighted_pressure_plate:15
 
 # Diamond Blocks
 block.10316 = diamond_block \
@@ -10463,7 +10469,7 @@ block.10360 =
 
 
 # Full Quartz Block
-block.10364 = quartz_block \
+block.10364 = quartz_block double_stone_slab:7 \
 \
 chisel:quartz chisel:quartz1 \
 \
@@ -10472,7 +10478,7 @@ pvj:marble_brick pvj:marble_brick_double_slab \
 twilightforest:castle_door twilightforest:castle_pillar twilightforest:castle_rune_brick twilightforest:castle_brick twilightforest:castle_door_vanished twilightforest:castle_unlock
 
 # Non-Full Quartz Block
-block.10365 = stone_slab:variant=quartz double_stone_slab:variant=quartz quartz_stairs \
+block.10365 = stone_slab:7 stone_slab:15 quartz_stairs \
 \
 dimdoors:quartz_dimensional_door dimdoors:quartz_door \
 \
@@ -10514,7 +10520,7 @@ quark:obsidian_pressure_plate \
 torchmaster:dread_lamp
 
 # Full Purpur Blocks
-block.10376 = purpur_block purpur_pillar \
+block.10376 = purpur_block purpur_double_slab purpur_pillar \
 \
 chisel:purpur chisel:purpur1 chisel:purpur2 \
 \
@@ -10524,14 +10530,14 @@ quark:duskbound_block_slab_double quark:duskbound_block quark:duskbound_lantern
 
 
 # Non-Full Purpur Blocks
-block.10377 = purpur_stairs purpur_slab purpur_double_slab \
+block.10377 = purpur_stairs purpur_slab \
 \
 placeableitems:block_chorus_popped \
 \
 quark:purpur_block_wall quark:duskbound_block_slab quark:duskbound_block_stairs quark:duskbound_block_wall
 
 # Full Snow Blocks
-block.10380 = snow snow_layer:layers=8 \
+block.10380 = snow snow_layer:7 \
 \
 quark:snow_bricks quark:snow_bricks_slab_double
 
@@ -10601,14 +10607,14 @@ torchmaster:feral_flare_lantern torchmaster:invisible_light \
 xreliquary:altar:1
 
 # Nether Brick Full Blocks
-block.10416 = nether_brick \
+block.10416 = nether_brick double_stone_slab:6 \
 \
 chisel:netherbrick:15 \
 \
 quark:charred_nether_bricks quark:charred_nether_brick_slab_double
 
 # Nether Brick Non-Full Blocks
-block.10417 = nether_brick_fence stone_slab:variant=nether_brick double_stone_slab:variant=nether_brick nether_brick_stairs \
+block.10417 = nether_brick_fence stone_slab:6 stone_slab:14 nether_brick_stairs \
 \
 growthcraft:rope_knot_nether_brick \
 \
@@ -10690,6 +10696,7 @@ block.10437 =
 
 # Prismarine Full Blocks
 block.10440 = prismarine \
+\
 chisel:prismarine chisel:prismarine1 chisel:prismarine2 \
 \
 cqrepoured:prismarine_carved cqrepoured:prismarine_cube cqrepoured:prismarine_large cqrepoured:prismarine_pillar cqrepoured:prismarine_small cqrepoured:prismarine_square \
@@ -10794,6 +10801,7 @@ block.10493 = grass_path
 
 # Torch
 block.10496 = torch \
+\
 tconstruct:stone_torch \
 \
 secretroomsmod:torch_lever \
@@ -10811,10 +10819,10 @@ block.10505 = chorus_plant \
 placeableitems:block_chorus_fruit
 
 # Chorus Flower
-block.10508 = chorus_flower:age=0 chorus_flower:age=1 chorus_flower:age=2 chorus_flower:age=3 chorus_flower:age=4
+block.10508 = chorus_flower:0 chorus_flower:1 chorus_flower:2 chorus_flower:3 chorus_flower:4
 
 # Chorus Flower - Fully Grown
-block.10512 = chorus_flower:age=5
+block.10512 = chorus_flower:5
 
 # Lit Furnace (Turned On)
 block.10516 = lit_furnace \
@@ -10841,17 +10849,17 @@ block.10528 =
 
 
 # Brown Mushroom Blocks
-block.10532 = brown_mushroom_block:variant=all_inside brown_mushroom_block:variant=north brown_mushroom_block:variant=north_east brown_mushroom_block:variant=east brown_mushroom_block:variant=center brown_mushroom_block:variant=south_east brown_mushroom_block:variant=south brown_mushroom_block:variant=south_west brown_mushroom_block:variant=west brown_mushroom_block:variant=north_west \
+block.10532 = brown_mushroom_block:0 brown_mushroom_block:1 brown_mushroom_block:2 brown_mushroom_block:3 brown_mushroom_block:4 brown_mushroom_block:5 brown_mushroom_block:6 brown_mushroom_block:7 brown_mushroom_block:8 brown_mushroom_block:9 \
 \
 twilightforest:huge_mushgloom:variant=all_inside twilightforest:huge_mushgloom:variant=north twilightforest:huge_mushgloom:variant=north_east twilightforest:huge_mushgloom:variant=east twilightforest:huge_mushgloom:variant=center twilightforest:huge_mushgloom:variant=south_east twilightforest:huge_mushgloom:variant=south twilightforest:huge_mushgloom:variant=south_west twilightforest:huge_mushgloom:variant=west twilightforest:huge_mushgloom:variant=north_west
 
 # Red Mushroom Blocks
-block.10536 = red_mushroom_block:variant=all_inside red_mushroom_block:variant=north red_mushroom_block:variant=north_east red_mushroom_block:variant=east red_mushroom_block:variant=center red_mushroom_block:variant=south_east red_mushroom_block:variant=south red_mushroom_block:variant=south_west red_mushroom_block:variant=west red_mushroom_block:variant=north_west \
+block.10536 = red_mushroom_block:0 red_mushroom_block:1 red_mushroom_block:2 red_mushroom_block:3 red_mushroom_block:4 red_mushroom_block:5 red_mushroom_block:6 red_mushroom_block:7 red_mushroom_block:8 red_mushroom_block:9 \
 \
 mod_lavacow:glowshroom_block_cap
 
 # Mushroom Stem Blocks
-block.10540 = brown_mushroom_block:variant=stem red_mushroom_block:variant=stem \
+block.10540 = brown_mushroom_block:10 red_mushroom_block:10 \
 \
 twilightforest:huge_mushgloom:variant=stem
 
@@ -10870,10 +10878,10 @@ openblocks:auto_enchantment_table \
 pvj:mystical_grill
 
 # End Portal Frame Without Ender Eye
-block.10554 = end_portal_frame:eye=false
+block.10554 = end_portal_frame:0 end_portal_frame:1 end_portal_frame:2 end_portal_frame:3
 
 # End Portal Frame With Ender Eye
-block.10556 = end_portal_frame:eye=true \
+block.10556 = end_portal_frame:4 end_portal_frame:5 end_portal_frame:6 end_portal_frame:7 \
 \
 placeableitems:block_ender_eye
 
@@ -10910,10 +10918,10 @@ block.10588 =
 block.10592 =
 
 # Redstone Dust (Wire) Any Power Level
-block.10596 = redstone_wire:power=1 redstone_wire:power=2 redstone_wire:power=3 redstone_wire:power=4 redstone_wire:power=5 redstone_wire:power=6 redstone_wire:power=7 redstone_wire:power=8 redstone_wire:power=9 redstone_wire:power=10 redstone_wire:power=11 redstone_wire:power=12 redstone_wire:power=13 redstone_wire:power=14 redstone_wire:power=15
+block.10596 = redstone_wire:1 redstone_wire:2 redstone_wire:3 redstone_wire:4 redstone_wire:5 redstone_wire:6 redstone_wire:7 redstone_wire:8 redstone_wire:9 redstone_wire:10 redstone_wire:11 redstone_wire:12 redstone_wire:13 redstone_wire:14 redstone_wire:15
 
 # Redstone Dust (Wire) 0 Power Level
-block.10601 = redstone_wire:power=0
+block.10601 = redstone_wire:0
 
 # Redstone Torch Lit (Turned On)
 block.10604 = redstone_torch
@@ -11347,10 +11355,10 @@ block.10891 = iron_door:powered=false
 block.10893 = iron_door:powered=true
 
 # Unpowered Iron Trapdoor - Euphoria Patches Redstone IPBR
-block.10897 = iron_trapdoor:open=false
+block.10897 = iron_trapdoor:0 iron_trapdoor:1 iron_trapdoor:2 iron_trapdoor:3 iron_trapdoor:8 iron_trapdoor:9 iron_trapdoor:10 iron_trapdoor:11
 
 # Powered Iron Trapdoor - Euphoria Patches Redstone IPBR
-block.10899 =iron_trapdoor:open=true
+block.10899 = iron_trapdoor:4 iron_trapdoor:5 iron_trapdoor:6 iron_trapdoor:7 iron_trapdoor:12 iron_trapdoor:13 iron_trapdoor:14 iron_trapdoor:15
 
 
 ##### CANDLES #####
@@ -11439,7 +11447,7 @@ block.10944 =
 block.10948 =
 
 # All snow layers except layer 8
-block.10953 = snow_layer:layers=1 snow_layer:layers=2 snow_layer:layers=3 snow_layer:layers=4 snow_layer:layers=5 snow_layer:layers=6 snow_layer:layers=7
+block.10953 = snow_layer:0 snow_layer:1 snow_layer:2 snow_layer:3 snow_layer:4 snow_layer:5 snow_layer:6
 
 # Target 0 Power
 block.10956 =
@@ -11448,12 +11456,12 @@ block.10956 =
 block.10960 =
 
 # Sponge
-block.10964 = sponge:wet=false \
+block.10964 = sponge:0 \
 \
 openblocks:sponge
 
 # Wet Sponge
-block.10968 = sponge:wet=true
+block.10968 = sponge:1
 
 # Solid Blocks With No Properties
 block.11110 = coal_block tnt \
@@ -11966,7 +11974,25 @@ block.60028 = bibliocraft:swordpedestal bibliocraft:typewriter bibliocraft:paint
 block.60032 =
 
 block.60036 =
+
+#  ██╗███████╗ ██╗ ██████╗     ██╗  ██╗███████╗██████╗ ███████╗
+# ███║╚════██║███║██╔═████╗    ██║  ██║██╔════╝██╔══██╗██╔════╝
+# ╚██║    ██╔╝╚██║██║██╔██║    ███████║█████╗  ██████╔╝█████╗  
+#  ██║   ██╔╝  ██║████╔╝██║    ██╔══██║██╔══╝  ██╔══██╗██╔══╝  
+#  ██║██╗██║██╗██║╚██████╔╝    ██║  ██║███████╗██║  ██║███████╗
+#  ╚═╝╚═╝╚═╝╚═╝╚═╝ ╚═════╝     ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝
+#  
+# Some blocks ID's we've defined just aren't compatible with 1.7.10 (Particularly IPBR Doors).
+# Optifine will ignore "invalid" ID's so we have to define them once again here, but with something it will understand.
+#if MC_VERSION == 10710
+
+# Oak Door
+block.10793 = wooden_door
+
+# Iron Door
+block.10891 = iron_door
 #endif
+
 
 # Blocks use what's called render layers. This tells the game how exactly to render a block:
 # 
@@ -11982,6 +12008,7 @@ block.60036 =
 # 
 # We can override the default render layer a block uses by defining them down below:
 
+#endif
 
 #layer.solid =
 


### PR DESCRIPTION
Self explanatory, only issue was the doors. Sadly we can't bring IPBR doors to 1.7.10 due to a lack of block-states. The way it's set up right now, we'll overwrite the define by having the same id be defined lower within the file if the version is equal to 1.7.10. I don't think we're supporting anything before 1.7.10 anyways unless something changes....