### PR TITLE
Bunch of new additions from various mods

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -900,8 +900,6 @@ undergarden:shiverstone_cloggrum_ore undergarden:depthrock_cloggrum_ore undergar
 \
 excavated_variants:tuff_uraninite_ore_poor excavated_variants:diorite_uraninite_ore_poor excavated_variants:andesite_uraninite_ore_poor excavated_variants:red_sandstone_uraninite_ore excavated_variants:biomesoplenty_black_sandstone_uraninite_ore excavated_variants:biomesoplenty_orange_sandstone_uraninite_ore excavated_variants:sandstone_uraninite_ore excavated_variants:calcite_uraninite_ore excavated_variants:biomesoplenty_white_sandstone_uraninite_ore excavated_variants:granite_uraninite_ore excavated_variants:smooth_basalt_uraninite_ore excavated_variants:dripstone_uraninite_ore excavated_variants:tuff_uraninite_ore excavated_variants:diorite_uraninite_ore excavated_variants:andesite_uraninite_ore excavated_variants:red_sandstone_uraninite_ore_dense excavated_variants:biomesoplenty_black_sandstone_uraninite_ore_dense excavated_variants:biomesoplenty_orange_sandstone_uraninite_ore_dense excavated_variants:calcite_uraninite_ore_dense excavated_variants:sandstone_uraninite_ore_dense excavated_variants:biomesoplenty_white_sandstone_uraninite_ore_dense excavated_variants:smooth_basalt_uraninite_ore_dense excavated_variants:granite_uraninite_ore_dense excavated_variants:dripstone_uraninite_ore_dense excavated_variants:tuff_uraninite_ore_dense excavated_variants:diorite_uraninite_ore_dense excavated_variants:andesite_uraninite_ore_dense excavated_variants:red_sandstone_uraninite_ore_poor excavated_variants:biomesoplenty_black_sandstone_uraninite_ore_poor excavated_variants:biomesoplenty_orange_sandstone_uraninite_ore_poor excavated_variants:calcite_uraninite_ore_poor excavated_variants:sandstone_uraninite_ore_poor excavated_variants:biomesoplenty_white_sandstone_uraninite_ore_poor excavated_variants:smooth_basalt_uraninite_ore_poor excavated_variants:granite_uraninite_ore_poor excavated_variants:dripstone_uraninite_ore_poor excavated_variants:twigs_schist_redstone_ore excavated_variants:twigs_schist_uraninite_ore excavated_variants:twigs_schist_uraninite_ore_poor excavated_variants:twigs_schist_uraninite_ore_dense excavated_variants:twigs_schist_inferium_ore excavated_variants:twigs_schist_prosperity_ore excavated_variants:twigs_rhyolite_redstone_ore excavated_variants:twigs_rhyolite_uraninite_ore excavated_variants:twigs_rhyolite_uraninite_ore_poor excavated_variants:twigs_rhyolite_uraninite_ore_dense excavated_variants:twigs_rhyolite_inferium_ore excavated_variants:twigs_rhyolite_prosperity_ore excavated_variants:twigs_bloodstone_quartz_ore excavated_variants:granite_yellorite_ore excavated_variants:diorite_yellorite_ore excavated_variants:andesite_yellorite_ore excavated_variants:granite_zinc_ore excavated_variants:diorite_zinc_ore excavated_variants:andesite_zinc_ore excavated_variants:create_asurine_redstone_ore excavated_variants:create_asurine_uraninite_ore excavated_variants:create_asurine_uraninite_ore_poor excavated_variants:create_asurine_uraninite_ore_dense excavated_variants:create_asurine_inferium_ore excavated_variants:create_asurine_prosperity_ore excavated_variants:create_crimsite_redstone_ore excavated_variants:create_crimsite_uraninite_ore excavated_variants:granite_osmium_ore excavated_variants:diorite_osmium_ore excavated_variants:andesite_osmium_ore excavated_variants:granite_aluminum_ore excavated_variants:diorite_aluminum_ore excavated_variants:andesite_aluminum_ore excavated_variants:create_scorchia_inferium_ore excavated_variants:create_scorchia_prosperity_ore excavated_variants:create_veridium_redstone_ore excavated_variants:create_veridium_uraninite_ore excavated_variants:create_veridium_uraninite_ore_poor excavated_variants:create_veridium_uraninite_ore_dense excavated_variants:create_veridium_inferium_ore excavated_variants:create_veridium_prosperity_ore excavated_variants:quark_limestone_redstone_ore excavated_variants:quark_limestone_uraninite_ore excavated_variants:quark_limestone_uraninite_ore_poor excavated_variants:quark_limestone_uraninite_ore_dense excavated_variants:quark_limestone_inferium_ore excavated_variants:quark_limestone_prosperity_ore excavated_variants:quark_jasper_redstone_ore excavated_variants:quark_jasper_uraninite_ore excavated_variants:quark_jasper_uraninite_ore_poor excavated_variants:quark_jasper_uraninite_ore_dense excavated_variants:quark_jasper_inferium_ore excavated_variants:quark_jasper_prosperity_ore excavated_variants:quark_shale_redstone_ore excavated_variants:quark_shale_uraninite_ore excavated_variants:quark_shale_uraninite_ore_poor excavated_variants:quark_shale_uraninite_ore_dense excavated_variants:quark_shale_inferium_ore excavated_variants:quark_shale_prosperity_ore excavated_variants:create_scoria_uraninite_ore_poor excavated_variants:create_scoria_uraninite_ore_dense excavated_variants:create_scoria_inferium_ore excavated_variants:create_scoria_prosperity_ore excavated_variants:create_scorchia_redstone_ore excavated_variants:create_scorchia_uraninite_ore excavated_variants:create_scorchia_uraninite_ore_poor excavated_variants:create_scorchia_quartz_ore excavated_variants:create_scorchia_uraninite_ore_dense excavated_variants:betterend_brimstone_ender_ore excavated_variants:betterend_umbralith_ender_ore excavated_variants:betterend_sandy_jadestone_ender_ore excavated_variants:betterend_flavolite_ender_ore excavated_variants:betterend_violecite_ender_ore excavated_variants:betterend_sulphuric_rock_ender_ore excavated_variants:betterend_azure_jadestone_ender_ore excavated_variants:betterend_virid_jadestone_ender_ore excavated_variants:betterend_brimstone_amber_ore excavated_variants:betterend_umbralith_amber_ore excavated_variants:betterend_sandy_jadestone_amber_ore excavated_variants:betterend_flavolite_amber_ore excavated_variants:betterend_violecite_amber_ore excavated_variants:betterend_sulphuric_rock_amber_ore excavated_variants:betterend_azure_jadestone_amber_ore excavated_variants:betterend_virid_jadestone_amber_ore \
 \
-deep_aether:skyjade_ore \
-\
 spelunkery:tuff_zinc_ore spelunkery:granite_zinc_ore spelunkery:diorite_zinc_ore spelunkery:andesite_zinc_ore spelunkery:diorite_diamond_ore spelunkery:raw_magnetite_block spelunkery:rough_emerald_block \
 \
 scpo:cobalt_ore_deepslate scpo:cobalt_ore scpo:iridium_ore scpo:deepslate_iridium_ore scpo:platinum_ore scpo:deepslate_platinum_ore \
@@ -1213,6 +1211,8 @@ securitycraft:flowing_fake_lava_block
 block.10072 = fire \
 tags_fire \
 \
+luminous_nether:soul_cauldron_orange_lit \
+\
 burnt:new_fire burnt:arrow_fire_burst burnt:wood_burn_half burnt:wood_burn burnt:blast_1 burnt:blast_2 burnt:blast_3 burnt:blast_4 burnt:burning_top burnt:burning_top_full burnt:burning_top_slab burnt:burning_top_slab_full \
 \
 whisperwoods:wisp_lantern_orange \
@@ -1222,6 +1222,8 @@ caverns_and_chasms:cupric_fire
 
 # Soul Fire
 block.10076 = soul_fire \
+\
+luminous_nether:soul_cauldron_blue_lit \
 \
 chipped:nether_jack_o_lantern \
 \
@@ -3646,6 +3648,8 @@ oreberries:iron_oreberry_bush oreberries:aluminum_oreberry_bush
 block.10272 = iron_ore \
 tags_iron_ores \
 \
+aether_ores:holystone_iron_ore \
+\
 universal_ores:andesite_iron_ore universal_ores:calcite_iron_ore universal_ores:diorite_iron_ore universal_ores:granite_iron_ore universal_ores:tuff_iron_ore \
 \
 excavated_variants:tuff_iron_ore excavated_variants:andesite_iron_ore excavated_variants:granite_iron_ore excavated_variants:quark_shale_iron_ore excavated_variants:quark_jasper_iron_ore excavated_variants:quark_limestone_iron_ore excavated_variants:smooth_basalt_iron_ore excavated_variants:diorite_iron_ore excavated_variants:dripstone_iron_ore excavated_variants:sandstone_iron_ore excavated_variants:calcite_iron_ore excavated_variants:red_sandstone_iron_ore excavated_variants:biomesoplenty_black_sandstone_iron_ore excavated_variants:biomesoplenty_orange_sandstone_iron_ore excavated_variants:biomesoplenty_white_sandstone_iron_ore excavated_variants:dripstone_iron_ore \
@@ -3702,6 +3706,8 @@ oreberries:copper_oreberry_bush oreberries:tin_oreberry_bush
 # Glowing Ores Copper
 block.10284 = copper_ore \
 tags_copper_ores \
+\
+aether_ores:holystone_copper_ore \
 \
 mythicupgrades:deepslate_topaz_ore mythicupgrades:topaz_ore \
 \
@@ -3860,6 +3866,8 @@ tags_gold_ores \
 \
 geode_plus:nether_gold_nugget_cluster_block \
 \
+aether_ores:holystone_gold_ore \
+\
 mysticalagriculture:inferium_ore mysticalagriculture:deepslate_inferium_ore mysticalagriculture:soulium_ore \
 \
 universal_ores:andesite_gold_ore universal_ores:calcite_gold_ore universal_ores:diorite_gold_ore universal_ores:granite_gold_ore universal_ores:tuff_gold_ore universal_ores:basalt_gold_ore universal_ores:blackstone_gold_ore \
@@ -4000,6 +4008,8 @@ securitycraft:nether_gold_mine
 block.10312 = gold_block \
 \
 betternether:cincinnasite_tile_large betternether:cincinnasite_forged betternether:cincinnasite_bricks betternether:cincinnasite_tile_small betternether:roof_tile_cincinnasite betternether:cincinnasite_pillar betternether:cincinnasite_brick_plate betternether:cincinnasite_carved betternether:cincinnasite_bricks_pillar betternether:cincinnasite_block \
+\
+luminous_nether:furnace_trophy luminous_nether:soul_furnace_trophy luminous_nether:basalt_exectioner_trophy luminous_nether:loot_vase luminous_nether:loot_vase_2 luminous_nether:loot_vase_3 luminous_nether:loot_vase_7 luminous_nether:loot_vase_8 luminous_nether:loot_vase_9 luminous_nether:executioner_trophy luminous_nether:mushlin_spewer_trophy luminous_nether:warped_spewer_trophy luminous_nether:cult_flag_top luminous_nether:cult_flag_bottom \
 \
 betterend:brimstone betterend:respawn_obelisk:shape=bottom betterend:amber_block \
 \
@@ -4156,6 +4166,8 @@ creategoggles:diamond_backtank
 # Glowing Ores Diamond
 block.10320 = diamond_ore \
 tags_diamond_ores \
+\
+aether_ores:holystone_diamond_ore \
 \
 mythicupgrades:deepslate_aquamarine_ore mythicupgrades:aquamarine_ore \
 \
@@ -4366,6 +4378,10 @@ additionallanterns:emerald_chain placeableitems:block_emerald
 block.10340 = emerald_ore \
 tags_emerald_ores \
 \
+aether_ores:holystone_emerald_ore \
+\
+deep_aether:skyjade_ore \
+\re
 mythicupgrades:deepslate_peridot_ore mythicupgrades:peridot_ore mythicupgrades:jade_ore \
 \
 universal_ores:andesite_emerald_ore universal_ores:calcite_emerald_ore universal_ores:diorite_emerald_ore universal_ores:granite_emerald_ore universal_ores:tuff_emerald_ore \
@@ -4494,6 +4510,8 @@ diagonalfences:extshape/lapis_fence
 # Glowing Ores Lapis
 block.10356 = lapis_ore \
 tags_lapis_ores \
+\
+aether_ores:holystone_lapis_ore \
 \
 mythicupgrades:sapphire_ore \
 \
@@ -5887,6 +5905,8 @@ block.10557 = quark:ender_watcher
 # Lantern
 block.10560 = lantern:hanging=false \
 \
+luminousworld:hanging_lantern \
+\
 decorative_blocks:brazier:lit=true \
 \
 blockus:redstone_lantern:hanging=false \
@@ -5948,6 +5968,8 @@ suppsquared:brass_lantern:hanging=true:lit=true suppsquared:copper_lantern:hangi
 
 # Soul Lantern
 block.10564 = soul_lantern \
+\
+lost_aether_content:light_gale_stone lost_aether_content:locked_light_gale_stone lost_aether_content:boss_doorway_light_gale_stone lost_aether_content:treasure_doorway_light_gale_stone lost_aether_content:trapped_light_gale_stone \
 \
 galosphere:allurite_cluster galosphere:glinted_allurite_cluster \
 \
@@ -6109,6 +6131,8 @@ block.10612 = redstone_ore:lit=false \
 \
 universal_ores:andesite_redstone_ore:lit=false universal_ores:calcite_redstone_ore:lit=false universal_ores:diorite_redstone_ore:lit=false universal_ores:granite_redstone_ore:lit=false universal_ores:tuff_redstone_ore:lit=false \
 \
+aether_ores:holystone_redstone_ore \
+\
 darkerdepths:aridrock_redstone_ore:lit=false darkerdepths:limestone_redstone_ore:lit=false \
 \
 ad_astra:red_industrial_lamp ad_astra:small_red_industrial_lamp \
@@ -6142,6 +6166,8 @@ chipped:small_red_soul_lantern
 # Redstone Ore Lit
 block.10616 = redstone_ore:lit=true \
 tags_redstone_ores \
+\
+aether_ores:holystone_redstone_ore \
 \
 betternether:nether_redstone_ore:lit=true \
 \
@@ -6296,6 +6322,10 @@ redbits:timer:input=false:powered=false redbits:detector:inverted=true:input=fal
 
 # Shroomlight
 block.10648 = shroomlight \
+\
+luminous_nether:fungirracklamporange \
+\
+aether_redux:flareblossom \
 \
 betternether:ink_bush_seed betternether:soul_lily_sapling betternether:cincinnasite_lantern betternether:cincinnasite_lantern_small betternether:black_apple_seed betternether:giant_lucis \
 \
@@ -6511,7 +6541,13 @@ diagonalfences:extshape/honeycomb_fence diagonalfences:extshape_blockus/honeycom
 # Ochre Froglight
 block.10680 = ochre_froglight \
 \
+deep_aether:light_nimbus_pillar deep_aether:locked_light_nimbus_pillar deep_aether:trapped_light_nimbus_pillar deep_aether:treasure_doorway_light_nimbus_pillar deep_aether:boss_doorway_light_nimbus_pillar deep_aether:light_nimbus_stone deep_aether:locked_light_nimbus_stone deep_aether:trapped_light_nimbus_stone deep_aether:boss_doorway_light_nimbus_stone deep_aether:treasure_doorway_light_nimbus_stone deep_aether:skyjade_lantern \
+\
+luminous_nether:large_popshroom luminous_nether:golden_pop_shroom luminous_nether:golden_mushroom luminous_nether:golden_fungi luminous_nether:fungirrack_lamp \
+\
 aether:ambrosium_torch aether:ambrosium_wall_torch \
+\
+aether_redux:sentrite_lantern \
 \
 inversia:ochre_selenite \
 \
@@ -6549,6 +6585,8 @@ luminax:yellow_block luminax:yellow_stairs luminax:yellow_slab luminax:yellow_wa
 
 # Verdant Froglight
 block.10684 = verdant_froglight \
+\
+luminous_nether:fungirracklamp_green \
 \
 inversia:verdant_selenite \
 \
@@ -7340,6 +7378,8 @@ immersive_weathering:waxed_iron_trapdoor:powered=true
 # Normal Candles
 block.10900 = candle:lit=true candle_cake:lit=true light_gray_candle:lit=true light_gray_candle_cake:lit=true gray_candle:lit=true gray_candle_cake:lit=true black_candle:lit=true black_candle_cake:lit=true white_candle:lit=true white_candle_cake:lit=true brown_candle:lit=true brown_candle_cake:lit=true \
 \
+luminous_nether:lit_skull_candle luminous_nether:lit_wither_skull_candle luminous_nether:candle_stand_top luminous_nether:wall_candle luminous_nether:nether_candle_stand_top luminous_nether:nether_wall_candle_on \
+\
 tags_candles \
 \
 supplementaries:statue:lit=true supplementaries:candle_holder_white:lit=true supplementaries:candle_holder_gray:lit=true supplementaries:candle_holder_light_gray:lit=true supplementaries:candle_holder_brown:lit=true supplementaries:candle_holder_black:lit=true supplementaries:candle_holder:lit=true \
@@ -7364,6 +7404,8 @@ tfc:candle:lit=true tfc:candle/white:lit=true tfc:candle/gray:lit=true tfc:candl
 
 # Red Candles
 block.10902 = red_candle:lit=true red_candle_cake:lit=true \
+\
+luminous_nether:ritual_table \
 \
 supplementaries:candle_holder_red:lit=true \
 \
@@ -7777,6 +7819,10 @@ block.20000 =
 # White - Also used For Black / Gray
 block.21000 = blockus:white_redstone_lamp_lit blockus:white_redstone_lamp:lit=true blockus:light_gray_redstone_lamp_lit blockus:light_gray_redstone_lamp:lit=true blockus:gray_redstone_lamp_lit blockus:gray_redstone_lamp:lit=true blockus:rainbow_neon \
 \
+luminous_nether:white_fire luminous_nether:soul_cauldron_lit luminous_nether:ghost_lamp luminous_nether:ghost_block luminous_nether:ghost_lantern luminous_nether:ghost_vent_block \
+\
+aether_redux:lumina \
+\
 chipped:glow_torch chipped:glow_wall_torch chipped:lightstick_redstone_torch:lit=true chipped:lightstick_redstone_wall_torch:lit=true chipped:nice_white_redstone_lamp:lit=true chipped:ornate_white_redstone_lamp:lit=true chipped:reinforced_white_redstone_lamp:lit=true chipped:smooth_white_redstone_lamp:lit=true chipped:thick_white_inlayed_redstone_lamp:lit=true chipped:edged_white_redstone_lamp:lit=true chipped:fancy_white_redstone_lamp:lit=true chipped:hived_white_redstone_lamp:lit=true chipped:inlayed_white_redstone_lamp:lit=true \
 \
 another_furniture:white_lamp:lit=true another_furniture:gray_lamp:lit=true another_furniture:light_gray_lamp:lit=true another_furniture:black_lamp:lit=true \
@@ -7824,6 +7870,8 @@ gtceu:brown_lamp:active=true gtceu:brown_borderless_lamp:active=true
 
 # Red
 block.21004 = blockus:red_redstone_lamp_lit blockus:red_redstone_lamp:lit=true \
+\
+luminous_nether:fungirracklampred \
 \
 another_furniture:red_lamp:lit=true \
 \
@@ -7941,8 +7989,11 @@ tconstruct:earth_slime_crystal_cluster tconstruct:small_earth_slime_crystal_bud 
 
 # Cyan
 block.21014 = blockus:cyan_redstone_lamp_lit blockus:cyan_redstone_lamp:lit=true \
+regions_unexplored:dropleaf 
 \
 another_furniture:cyan_lamp:lit=true \
+\
+aether_redux:luxweed \
 \
 betterend:terminite_bulb_lantern_cyan betterend:thallasium_bulb_lantern_cyan betterend:iron_bulb_lantern_cyan \
 \
@@ -7963,7 +8014,11 @@ tconstruct:sky_slime_crystal_cluster tconstruct:small_sky_slime_crystal_bud tcon
 # Light Blue
 block.21016 = blockus:light_blue_redstone_lamp_lit blockus:light_blue_redstone_lamp:lit=true \
 \
+luminous_nether:fungirracklampblue \
+\
 aether:sentry_stone aether:locked_sentry_stone aether:treasure_doorway_sentry_stone aether:trapped_sentry_stone \
+\
+aether_redux:runelight:lit=true aether_redux:locked_runelight:lit=true aether_redux:sentry_pillar aether_redux:locked_sentry_pillar aether_redux:trapped_sentry_pillar aether_redux:boss_doorway_sentry_pillar aether_redux:sentry_base aether_redux:locked_sentry_base aether_redux:boss_doorway_sentry_base aether_redux:trapped_sentry_base \
 \
 another_furniture:light_blue_lamp:lit=true \
 \
@@ -8013,6 +8068,8 @@ caverns_and_chasms:lapis_lamp
 # Purple
 block.21020 = blockus:amethyst_lamp blockus:purple_redstone_lamp_lit blockus:purple_redstone_lamp:lit=true blockus:amethyst_lantern blockus:amethyst_lantern_block \
 \
+luminous_nether:fungirracklamppurple \
+\
 another_furniture:purple_lamp:lit=true \
 \
 betterend:thallasium_bulb_lantern_purple betterend:terminite_bulb_lantern_purple betterend:iron_bulb_lantern_purple \
@@ -8054,6 +8111,9 @@ gtceu:magenta_lamp:active=true gtceu:magenta_borderless_lamp:active=true gtceu:t
 
 # Pink
 block.21024 = blockus:pink_redstone_lamp_lit blockus:pink_redstone_lamp:lit=true \
+regions_unexplored:glistering_ivy regions_unexplored:glister_bulb regions_unexplored:glister_spire \
+\
+luminous_nether:fungirracklamp_pink \
 \
 another_furniture:pink_lamp:lit=true \
 \
@@ -10380,6 +10440,8 @@ block.10308 = thermalfoundation:ore_fluid:3
 
 # Gold Blocks
 block.10312 = gold_block \
+\
+luminous_nether:furnace_trophy luminous_nether:soul_furnace_trophy luminous_nether:basalt_exectioner_trophy luminous_nether:loot_vase luminous_nether:loot_vase_2 luminous_nether:loot_vase_3 luminous_nether:loot_vase_7 luminous_nether:loot_vase_8 luminous_nether:loot_vase_9 luminous_nether:executioner_trophy luminous_nether:mushlin_spewer_trophy luminous_nether:warped_spewer_trophy luminous_nether:cult_flag_top luminous_nether:cult_flag_bottom \
 \
 tconstruct:metal:1 tconstruct:metal:5 tconstruct:metal:6 \
 \

--- a/block.properties
+++ b/block.properties
@@ -6730,8 +6730,6 @@ openblocks:tank \
 \
 placeableitems:block_disc \
 \
-quark:framed_glass quark:framed_glass_pane \
-\
 soulshardsrespawn:soul_cage \
 \
 thermalfoundation:glass thermalfoundation:glass_alloy \

--- a/item.properties
+++ b/item.properties
@@ -92,6 +92,12 @@ item.44007 = ochre_froglight \
 \
 aether:ambrosium_torch \
 \
+aether_redux:sentrite_lantern \
+\
+deep_aether:light_nimbus_pillar deep_aether:locked_light_nimbus_pillar deep_aether:trapped_light_nimbus_pillar deep_aether:treasure_doorway_light_nimbus_pillar deep_aether:boss_doorway_light_nimbus_pillar deep_aether:light_nimbus_stone deep_aether:locked_light_nimbus_stone deep_aether:trapped_light_nimbus_stone deep_aether:boss_doorway_light_nimbus_stone deep_aether:treasure_doorway_light_nimbus_stone deep_aether:skyjade_lantern \
+\
+luminous_nether:large_popshroom luminous_nether:golden_pop_shroom luminous_nether:golden_mushroom luminous_nether:golden_fungi luminous_nether:fungirrack_lamp \
+\
 inversia:ochre_selenite \
 \
 astrological:ochre_selenite \
@@ -126,6 +132,8 @@ securitycraft:reinforced_ochre_froglight
 
 # Verdant Froglight
 item.44008 = verdant_froglight \
+\
+luminous_nether:fungirracklamp_green \
 \
 inversia:verdant_selenite \
 \
@@ -229,6 +237,8 @@ item.44012 = lantern \
 \
 tconstruct:seared_lantern tconstruct:scorched_lantern \
 \
+luminousworld:hanging_lantern \
+\
 amendments:wall_lantern \
 \
 quark:blaze_lantern \
@@ -279,6 +289,10 @@ securitycraft:reinforced_sea_lantern
 
 # Shroomlight
 item.44019 = shroomlight \
+\
+luminous_nether:fungirracklamporange \
+\
+aether_redux:flareblossom \
 \
 betternether:ink_bush_seed betternether:soul_lily_sapling betternether:cincinnasite_lantern betternether:cincinnasite_lantern_small betternether:black_apple_seed betternether:giant_lucis \
 \
@@ -354,6 +368,8 @@ aquatictorches:aquatic_torch
 
 # Soul Lantern
 item.44029 = soul_lantern \
+\
+lost_aether_content:light_gale_stone lost_aether_content:locked_light_gale_stone lost_aether_content:boss_doorway_light_gale_stone lost_aether_content:treasure_doorway_light_gale_stone lost_aether_content:trapped_light_gale_stone \
 \
 galosphere:allurite_cluster galosphere:glinted_allurite_cluster \
 \
@@ -512,6 +528,8 @@ simplylight:illuminant_brown_block_on
 # Modded Light Source - Red
 item.44070 = blockus:red_redstone_lamp_lit \
 \
+luminous_nether:fungirracklampred \
+\
 betterend:thallasium_bulb_lantern_red betterend:terminite_bulb_lantern_red betterend:iron_bulb_lantern_red \
 \
 hearth_and_home:red_paper_lantern \
@@ -602,6 +620,8 @@ item.44075 = blockus:cyan_redstone_lamp_lit \
 \
 betterend:terminite_bulb_lantern_cyan betterend:thallasium_bulb_lantern_cyan betterend:iron_bulb_lantern_cyan \
 \
+aether_redux:luxweed \
+\
 hearth_and_home:cyan_paper_lantern \
 \
 vintagedelight:salt_lamp_cyan \
@@ -618,7 +638,11 @@ tconstruct:sky_slime_crystal_cluster tconstruct:small_sky_slime_crystal_bud tcon
 # Modded Light Source - Light Blue
 item.44076 = blockus:light_blue_redstone_lamp_lit \
 \
+luminous_nether:fungirracklampblue \
+\
 aether:sentry_stone aether:locked_sentry_stone aether:trapped_sentry_stone aether:treasure_doorway_sentry_stone \
+\
+aether_redux:runelight:lit=true aether_redux:locked_runelight:lit=true aether_redux:sentry_pillar aether_redux:locked_sentry_pillar aether_redux:trapped_sentry_pillar aether_redux:boss_doorway_sentry_pillar aether_redux:sentry_base aether_redux:locked_sentry_base aether_redux:boss_doorway_sentry_base aether_redux:trapped_sentry_base \
 \
 betterend:thallasium_bulb_lantern_light_blue betterend:iron_bulb_lantern_light_blue betterend:terminite_bulb_lantern_light_blue \
 \
@@ -654,6 +678,8 @@ chipped:blue_redstone_torch
 # Modded Light Source - Purple
 item.44078 = blockus:amethyst_lamp blockus:purple_redstone_lamp_lit blockus:amethyst_lantern blockus:amethyst_lantern_block \
 \
+luminous_nether:fungirracklamppurple \
+\
 betterend:thallasium_bulb_lantern_purple betterend:terminite_bulb_lantern_purple betterend:iron_bulb_lantern_purple \
 \
 hearth_and_home:purple_paper_lantern \
@@ -686,6 +712,10 @@ simplylight:illuminant_magenta_block_on
 
 # Modded Light Source - Pink
 item.44080 = blockus:pink_redstone_lamp_lit \
+\
+luminous_nether:fungirracklamp_pink \
+\
+regions_unexplored:glistering_ivy regions_unexplored:glister_bulb regions_unexplored:glister_spire \
 \
 betterend:thallasium_bulb_lantern_pink betterend:terminite_bulb_lantern_pink betterend:iron_bulb_lantern_pink \
 \


### PR DESCRIPTION
Luminous nether - all light blocks given color and trophies given gold reflections
Luminous world - Tall torches compatible with vanilla ones
Aether Ores - All ores (diamond ore is a bit scuffed but not sure what I can do about it
Deep Aether - Dungeon bricks given color, skyjade lanterns & Skyjade ore moved from auto modded ores to emerald ores as well as some 
Aether Redux - Dungeon bricks, sentrite lanterns, glowing flower blocks & sporing blightwood 
Lost Aether  - Dungeon bricks
Regions Unexplored - drop leafs given cyan color and glistering foliage set given pink color
Quark - Removed framed glass from mob spawner category causing it to glow purple

Might be more I missed but this should be everything added. 