### PR TITLE
Add all new blocks from create 6.0 to block.properties and adjust locations of some existing blocks to better fit their texture.

### DIFF
--- a/addedMods.md
+++ b/addedMods.md
@@ -95,7 +95,7 @@ Here we can keep track of what mods has been added and what version a contributo
 | [Construct's Armory](https://www.curseforge.com/minecraft/mc-mods/constructs-armory) | 1.3.4 | Miniscule |
 | [Corn Delight](https://modrinth.com/mod/corn-delight) | | In Testing | # Corn plants are 2 blocks tall, current blocks.properties only has one entry!
 | [Countered's Terrain Slabs](https://modrinth.com/mod/countereds-terrain-slabs) | 1.3.0 | Fully Added |
-| [Create](https://modrinth.com/mod/create) | 0.5.1-j-build.1631 | Fully Added |
+| [Create](https://modrinth.com/mod/create) | 6.0.0 | In Testing |
 | [Create Big Cannons](https://modrinth.com/mod/create-big-cannons) | 5.8.2 | Fully Added  |
 | [Create Crafts & Additions](https://modrinth.com/mod/createaddition) | 1.2.4 | Fully Added |
 | [Create Deco](https://modrinth.com/mod/create-deco) | 2.0.2 | Fully Added |

--- a/addedMods.md
+++ b/addedMods.md
@@ -95,7 +95,7 @@ Here we can keep track of what mods has been added and what version a contributo
 | [Construct's Armory](https://www.curseforge.com/minecraft/mc-mods/constructs-armory) | 1.3.4 | Miniscule |
 | [Corn Delight](https://modrinth.com/mod/corn-delight) | | In Testing | # Corn plants are 2 blocks tall, current blocks.properties only has one entry!
 | [Countered's Terrain Slabs](https://modrinth.com/mod/countereds-terrain-slabs) | 1.3.0 | Fully Added |
-| [Create](https://modrinth.com/mod/create) | 0.5.1-j-build.1631 | Fully Added |
+| [Create](https://modrinth.com/mod/create) | 6.0.4 | In Testing |
 | [Create Big Cannons](https://modrinth.com/mod/create-big-cannons) | 5.8.2 | Fully Added  |
 | [Create Crafts & Additions](https://modrinth.com/mod/createaddition) | 1.2.4 | Fully Added |
 | [Create Deco](https://modrinth.com/mod/create-deco) | 2.0.2 | Fully Added |

--- a/addedMods.md
+++ b/addedMods.md
@@ -95,7 +95,7 @@ Here we can keep track of what mods has been added and what version a contributo
 | [Construct's Armory](https://www.curseforge.com/minecraft/mc-mods/constructs-armory) | 1.3.4 | Miniscule |
 | [Corn Delight](https://modrinth.com/mod/corn-delight) | | In Testing | # Corn plants are 2 blocks tall, current blocks.properties only has one entry!
 | [Countered's Terrain Slabs](https://modrinth.com/mod/countereds-terrain-slabs) | 1.3.0 | Fully Added |
-| [Create](https://modrinth.com/mod/create) | 6.0.0 | In Testing |
+| [Create](https://modrinth.com/mod/create) | 0.5.1-j-build.1631 | Fully Added |
 | [Create Big Cannons](https://modrinth.com/mod/create-big-cannons) | 5.8.2 | Fully Added  |
 | [Create Crafts & Additions](https://modrinth.com/mod/createaddition) | 1.2.4 | Fully Added |
 | [Create Deco](https://modrinth.com/mod/create-deco) | 2.0.2 | Fully Added |

--- a/block.properties
+++ b/block.properties
@@ -1127,13 +1127,11 @@ railways:generic_crossing
 block.10045 = cauldron hopper:enabled=true \
 tags_cauldrons \
 \
-create:basin create:chute create:empty_blaze_burner \
+create:basin create:chute create:empty_blaze_burner create:blaze_burner:blaze=none create:packager create:repackager \
 \
 supplementaries:faucet supplementaries:cage \
 \
 securitycraft:reinforced_hopper:enabled=true securitycraft:reinforced_cauldron \
-\
-create:blaze_burner:blaze=none \
 \
 createaddition:liquid_blaze_burner:blaze=none
 
@@ -1556,7 +1554,7 @@ betternether:soul_sandstone_smooth_stairs betternether:soul_sandstone_stairs bet
 \
 betterend:andesite_pedestal betterend:azure_jadestone_stairs betterend:azure_jadestone_slab betterend:azure_jadestone_wall betterend:azure_jadestone_button betterend:azure_jadestone_plate betterend:azure_jadestone_pedestal betterend:azure_jadestone_bricks_stairs betterend:azure_jadestone_bricks_slab betterend:azure_jadestone_bricks_wall \
 \
-create:andesite_door create:andesite_ladder create:andesite_bars create:andesite_scaffolding create:andesite_tunnel create:cut_andesite_stairs create:cut_andesite_slab create:cut_andesite_wall create:polished_cut_andesite_stairs create:polished_cut_andesite_slab create:polished_cut_andesite_wall create:cut_andesite_brick_stairs create:cut_andesite_brick_slab create:cut_andesite_brick_wall create:small_andesite_brick_stairs create:small_andesite_brick_slab create:small_andesite_brick_wall create:display_board create:track_station create:track_signal create:contraption_controls create:mechanical_drill create:mechanical_saw create:deployer create:portable_storage_interface create:mechanical_harvester create:mechanical_plough create:mechanical_roller create:rope_pulley create:andesite_encased_cogwheel create:andesite_encased_large_cogwheel create:andesite_encased_shaft create:mechanical_piston create:mechanical_piston_head create:sticky_mechanical_piston create:sticky_mechanical_piston_head create:piston_extension_pole create:gearbox create:vertical_gearbox create:encased_chain_drive create:water_wheel create:encased_fan create:nozzle create:millstone create:mechanical_press create:mechanical_mixer create:depot create:weighted_ejector create:speedometer create:stressometer create:windmill_bearing create:mechanical_bearing create:gantry_carriage \
+create:andesite_door create:andesite_ladder create:andesite_bars create:andesite_scaffolding create:andesite_tunnel create:cut_andesite_stairs create:cut_andesite_slab create:cut_andesite_wall create:polished_cut_andesite_stairs create:polished_cut_andesite_slab create:polished_cut_andesite_wall create:cut_andesite_brick_stairs create:cut_andesite_brick_slab create:cut_andesite_brick_wall create:small_andesite_brick_stairs create:small_andesite_brick_slab create:small_andesite_brick_wall create:display_board create:track_station create:track_signal create:contraption_controls create:mechanical_drill create:mechanical_saw create:deployer create:portable_storage_interface create:mechanical_harvester create:mechanical_plough create:mechanical_roller create:rope_pulley create:andesite_encased_cogwheel create:andesite_encased_large_cogwheel create:andesite_encased_shaft create:mechanical_piston create:mechanical_piston_head create:sticky_mechanical_piston create:sticky_mechanical_piston_head create:piston_extension_pole create:gearbox create:vertical_gearbox create:encased_chain_drive create:water_wheel create:encased_fan create:nozzle create:millstone create:mechanical_press create:mechanical_mixer create:depot create:weighted_ejector create:speedometer create:stressometer create:windmill_bearing create:mechanical_bearing create:gantry_carriage create:chain_conveyor create:item_hatch create:package_frogport create:stock_link create:stock_ticker create:andesite_table_cloth create:black_table_cloth create:belt:casing=true \
 \
 extractinator:extractinator \
 \
@@ -2453,7 +2451,9 @@ quark:custom_bookshelf:variant=bookshelf_birch quark:vertical_planks:variant=ver
 \
 storagedrawers:trim:variant=birch \
 \
-twilightforest:fire_jet:variant=encased_smoker_off twilightforest:fire_jet:variant=encased_smoker_on twilightforest:mangrove_doubleslab twilightforest:mangrove_planks twilightforest:mangrove_doubleslab twilightforest:mangrove_planks twilightforest:mine_doubleslab twilightforest:mine_planks twilightforest:tower_device
+twilightforest:fire_jet:variant=encased_smoker_off twilightforest:fire_jet:variant=encased_smoker_on twilightforest:mangrove_doubleslab twilightforest:mangrove_planks twilightforest:mangrove_doubleslab twilightforest:mangrove_planks twilightforest:mine_doubleslab twilightforest:mine_planks twilightforest:tower_device \
+\
+create:cardboard_block create:bound_cardboard_block
 
 # Birch Non-Full Blocks
 block.10173 = birch_fence birch_fence_gate:powered=false birch_button:powered=false birch_pressure_plate:powered=false birch_slab birch_stairs birch_trapdoor:powered=false \
@@ -3457,7 +3457,7 @@ block.10249 = create:netherite_backtank \
 \
 bakery:iron_table bakery:iron_chair bakery:iron_bench \
 \
-create:metal_girder create:metal_girder_encased_shaft create:item_vault \
+create:metal_girder create:metal_girder_encased_shaft create:item_vault create:redstone_requester \
 \
 extshape:netherite_stairs extshape:netherite_slab extshape:netherite_vertical_slab extshape:netherite_vertical_stairs extshape:netherite_quarter_piece extshape:netherite_vertical_quarter_piece extshape:netherite_wall extshape:netherite_fence extshape:netherite_fence_gate extshape:netherite_button extshape:netherite_pressure_plate \
 \
@@ -3496,7 +3496,7 @@ diagonalfences:extshape/ancient_debris_fence
 # Iron Bars
 block.10257 = iron_bars \
 \
-create:ornate_iron_window create:ornate_iron_window_pane \
+create:ornate_iron_window create:ornate_iron_window_pane  create:industrial_iron_window create:weathered_iron_window  create:industrial_iron_window_pane create:weathered_iron_window _pane\
 \
 supplementaries:iron_gate \
 \
@@ -3800,7 +3800,7 @@ farm_and_charm:silo_copper \
 \
 supplementaries:cog_block \
 \
-create:elevator_pulley create:copper_shingles create:waxed_copper_shingles create:copper_tiles create:waxed_copper_tiles create:copper_casing create:weathered_copper_shingles create:waxed_weathered_copper_shingles create:weathered_copper_tiles create:waxed_weathered_copper_tiles create:weathered_copper_casing create:exposed_copper_shingles create:exposed_copper_tiles create:oxidized_copper_shingles create:oxidized_copper_tiles create:waxed_exposed_copper_shingles create:waxed_exposed_copper_tiles create:waxed_oxidized_copper_shingles create:waxed_oxidized_copper_tiles \
+create:elevator_pulley create:copper_shingles create:waxed_copper_shingles create:copper_tiles create:waxed_copper_tiles create:copper_casing create:weathered_copper_shingles create:waxed_weathered_copper_shingles create:weathered_copper_tiles create:waxed_weathered_copper_tiles create:weathered_copper_casing create:exposed_copper_shingles create:exposed_copper_tiles create:oxidized_copper_shingles create:oxidized_copper_tiles create:waxed_exposed_copper_shingles create:waxed_exposed_copper_tiles create:waxed_oxidized_copper_shingles create:waxed_oxidized_copper_tiles create:brass_casing create:weathered_iron_block \
 \
 quark:raw_copper_bricks \
 \
@@ -3839,7 +3839,7 @@ automobility:automobile_assembler \
 \
 candlelight:cooking_pot candlelight:cooking_pan \
 \
-create:clockwork_bearing create:copper_backtank create:fluid_pipe create:glass_fluid_pipe create:encased_fluid_pipe create:fluid_tank create:hose_pulley create:item_drain create:spout create:copper_valve_handle create:mechanical_pump create:smart_fluid_pipe create:fluid_valve create:portable_fluid_interface create:steam_engine create:steam_whistle create:steam_whistle_extension create:copper_ladder create:copper_scaffolding create:copper_door create:copper_bars create:copper_shingle_slab create:copper_shingle_stairs create:waxed_copper_shingle_stairs create:copper_tile_slab create:copper_tile_stairs create:waxed_copper_tile_slab create:waxed_copper_tile_stairs create:weathered_copper_shingle_slab create:weathered_copper_shingle_stairs create:waxed_weathered_copper_shingle_stairs create:weathered_copper_tile_slab create:weathered_copper_tile_stairs create:waxed_weathered_copper_tile_slab create:waxed_weathered_copper_tile_stairs create:exposed_copper_shingle_slab create:exposed_copper_shingle_stairs create:exposed_copper_tile_slab create:exposed_copper_tile_stairs create:oxidized_copper_shingle_slab create:oxidized_copper_shingle_stairs create:oxidized_copper_tile_slab create:oxidized_copper_tile_stairs create:waxed_copper_shingle_slab create:waxed_exposed_copper_shingle_slab create:waxed_exposed_copper_shingle_stairs create:waxed_exposed_copper_tile_slab create:waxed_exposed_copper_tile_stairs create:waxed_oxidized_copper_shingle_slab create:waxed_oxidized_copper_shingle_stairs create:waxed_oxidized_copper_tile_slab create:waxed_oxidized_copper_tile_stairs create:waxed_weathered_copper_shingle_slab \
+create:clockwork_bearing create:copper_backtank create:fluid_pipe create:glass_fluid_pipe create:encased_fluid_pipe create:fluid_tank create:hose_pulley create:item_drain create:spout create:copper_valve_handle create:mechanical_pump create:smart_fluid_pipe create:fluid_valve create:portable_fluid_interface create:steam_engine create:steam_whistle create:steam_whistle_extension create:copper_ladder create:copper_scaffolding create:copper_door create:copper_bars create:copper_shingle_slab create:copper_shingle_stairs create:waxed_copper_shingle_stairs create:copper_tile_slab create:copper_tile_stairs create:waxed_copper_tile_slab create:waxed_copper_tile_stairs create:weathered_copper_shingle_slab create:weathered_copper_shingle_stairs create:waxed_weathered_copper_shingle_stairs create:weathered_copper_tile_slab create:weathered_copper_tile_stairs create:waxed_weathered_copper_tile_slab create:waxed_weathered_copper_tile_stairs create:exposed_copper_shingle_slab create:exposed_copper_shingle_stairs create:exposed_copper_tile_slab create:exposed_copper_tile_stairs create:oxidized_copper_shingle_slab create:oxidized_copper_shingle_stairs create:oxidized_copper_tile_slab create:oxidized_copper_tile_stairs create:waxed_copper_shingle_slab create:waxed_exposed_copper_shingle_slab create:waxed_exposed_copper_shingle_stairs create:waxed_exposed_copper_tile_slab create:waxed_exposed_copper_tile_stairs create:waxed_oxidized_copper_shingle_slab create:waxed_oxidized_copper_shingle_stairs create:waxed_oxidized_copper_tile_slab create:waxed_oxidized_copper_tile_stairs create:waxed_weathered_copper_shingle_slab create:factory_gauge create:brass_table_cloth create:brass_encased_shaft create:brass_encased_cogwheel create:brass_encased_large_cogwheel create:brass_scaffolding create:copper_table_cloth \
 \
 quark:raw_copper_bricks_stairs quark:raw_copper_bricks_slab quark:raw_copper_bricks_wall \
 \
@@ -4054,7 +4054,7 @@ luminous_nether:furnace_trophy luminous_nether:soul_furnace_trophy luminous_neth
 \
 betterend:brimstone betterend:respawn_obelisk:shape=bottom betterend:amber_block \
 \
-create:brass_casing create:railway_casing create:brass_block \
+create:railway_casing create:brass_block \
 \
 cobblemon:relic_coin_sack cobblemon:relic_coin_pouch \
 \
@@ -4111,7 +4111,7 @@ blockus:gold_plating blockus:gold_plating_stairs blockus:gold_plating_slab block
 \
 dimdoors:gold_door dimdoors:gold_dimensional_door \
 \
-create:train_door create:train_trapdoor create:mechanical_crafter create:flywheel create:rotation_speed_controller create:mechanical_arm create:controls create:brass_tunnel create:brass_ladder create:brass_bars create:brass_door create:brass_trapdoor create:brass_encased_cogwheel create:brass_encased_large_cogwheel create:brass_encased_shaft create:brass_scaffolding \
+create:train_door create:train_trapdoor create:mechanical_crafter create:flywheel create:rotation_speed_controller create:mechanical_arm create:controls create:brass_tunnel create:brass_ladder create:brass_bars create:brass_door create:brass_trapdoor create:desk_bell \
 \
 createdeco:brass_bars createdeco:brass_bars_overlay createdeco:brass_coinstack createdeco:brass_door createdeco:brass_hull createdeco:brass_sheet_metal createdeco:brass_trapdoor createdeco:gold_coinstack createdeco:locked_brass_door createdeco:brass_catwalk createdeco:brass_catwalk_railing createdeco:brass_catwalk_stairs createdeco:brass_support createdeco:brass_support_wedge createdeco:brass_mesh_fence createdeco:orange_placard createdeco:magenta_placard createdeco:light_blue_placard createdeco:yellow_placard createdeco:lime_placard createdeco:pink_placard createdeco:gray_placard createdeco:light_gray_placard createdeco:cyan_placard createdeco:purple_placard createdeco:blue_placard createdeco:brown_placard createdeco:green_placard createdeco:red_placard createdeco:black_placard \
 \
@@ -6587,7 +6587,9 @@ block.10677 = extshape:honeycomb_stairs extshape:honeycomb_slab extshape:honeyco
 \
 extshape_blockus:honeycomb_brick_vertical_slab extshape_blockus:honeycomb_brick_vertical_stairs extshape_blockus:honeycomb_brick_quarter_piece extshape_blockus:honeycomb_brick_vertical_quarter_piece extshape_blockus:honeycomb_brick_fence extshape_blockus:honeycomb_brick_fence_gate extshape_blockus:honeycomb_brick_pressure_plate \
 \
-diagonalfences:extshape/honeycomb_fence diagonalfences:extshape_blockus/honeycomb_brick_fence
+diagonalfences:extshape/honeycomb_fence diagonalfences:extshape_blockus/honeycomb_brick_fence \
+\
+create:white_postbox create:orange_postbox create:magenta_postbox create:light_blue_postbox create:yellow_postbox create:lime_postbox create:pink_postbox create:gray_postbox create:light_gray_postbox create:cyan_postbox create:purple_postbox create:blue_postbox create:brown_postbox create:green_postbox create:red_postbox create:black_postbox create:white_table_cloth create:orange_table_cloth create:magenta_table_cloth create:light_blue_table_cloth create:yellow_table_cloth create:lime_table_cloth create:pink_table_cloth create:gray_table_cloth create:light_gray_table_cloth create:cyan_table_cloth create:purple_table_cloth create:blue_table_cloth create:brown_table_cloth create:green_table_cloth create:red_table_cloth
 
 
 ##### FROGLIGHTS #####
@@ -7049,7 +7051,9 @@ growthcraft_bamboo:bamboo_door growthcraft_bamboo:bamboo_fence growthcraft_bambo
 \
 growthcraft_fishtrap:fishtrap_bamboo \
 \
-quark:reed_block_slab quark:reed_block_stairs quark:reed_block_wall
+quark:reed_block_slab quark:reed_block_stairs quark:reed_block_wall \
+\
+create:bamboo_window create:bamboo_window_pane
 
 # Powered Bamboo blocks - Euphoria Patches Redstone IPBR
 block.10759 = bamboo_trapdoor:powered=true bamboo_fence_gate:powered=true bamboo_pressure_plate:powered=true bamboo_button:powered=true
@@ -7142,7 +7146,9 @@ diagonalfences:extshape/cherry_log_fence diagonalfences:extshape/cherry_wood_fen
 \
 wilderwild:hollowed_cherry_log \
 \
-blockus:cherry_post
+blockus:cherry_post \
+\
+create:cherry_window create:cherry_window_pane
 
 # Torchflower
 block.10769 = torchflower \
@@ -7747,7 +7753,7 @@ travelersbackpack:warden travelersbackpack:standard travelersbackpack:netherite 
 \
 farmersdelight:apple_pie farmersdelight:chocolate_pie farmersdelight:sweet_berry_cheesecake farmersdelight:carrot_crate farmersdelight:potato_crate farmersdelight:beetroot_crate farmersdelight:cabbage_crate farmersdelight:tomato_crate farmersdelight:onion_crate farmersdelight:rice_bag farmersdelight:brown_mushroom_colony farmersdelight:red_mushroom_colony farmersdelight:roast_chicken_block farmersdelight:honey_glazed_ham_block farmersdelight:shepherds_pie_block farmersdelight:rice_roll_medley_block \
 \
-create:cuckoo_clock create:mysterious_cuckoo_clock create:copycat_bars create:copycat_base create:copycat_panel create:copycat_step create:analog_lever create:belt create:rope create:chocolate create:honey create:crushing_wheel create:crushing_wheel_controller create:minecart_anchor create:large_bogey create:small_bogey create:large_water_wheel create:water_wheel_structure create:placard create:powered_shaft create:pulley_magnet create:track create:fake_track create:wooden_bracket create:metal_bracket create:black_valve_handle create:blue_valve_handle create:brown_valve_handle create:cyan_valve_handle create:gray_valve_handle create:green_valve_handle create:light_blue_valve_handle create:light_gray_valve_handle create:lime_valve_handle create:magenta_valve_handle create:orange_valve_handle create:pink_valve_handle create:purple_valve_handle create:red_valve_handle create:white_valve_handle create:yellow_valve_handle \
+create:cuckoo_clock create:mysterious_cuckoo_clock create:copycat_bars create:copycat_base create:copycat_panel create:copycat_step create:analog_lever create:belt:casing=false create:rope create:chocolate create:honey create:crushing_wheel create:crushing_wheel_controller create:minecart_anchor create:large_bogey create:small_bogey create:large_water_wheel create:water_wheel_structure create:placard create:powered_shaft create:pulley_magnet create:track create:fake_track create:wooden_bracket create:metal_bracket create:black_valve_handle create:blue_valve_handle create:brown_valve_handle create:cyan_valve_handle create:gray_valve_handle create:green_valve_handle create:light_blue_valve_handle create:light_gray_valve_handle create:lime_valve_handle create:magenta_valve_handle create:orange_valve_handle create:pink_valve_handle create:purple_valve_handle create:red_valve_handle create:white_valve_handle create:yellow_valve_handle \
 \
 createbigcannons:built_up_cannon createbigcannons:powder_charge createbigcannons:big_cartridge createbigcannons:big_cartridge createbigcannons:solid_shot createbigcannons:ap_shot createbigcannons:mortar_stone createbigcannons:mortar_stone_projectile createbigcannons:bag_of_grapeshot createbigcannons:he_shell createbigcannons:ap_shell createbigcannons:shrapnel_shell createbigcannons:fluid_shell createbigcannons:smoke_shell createbigcannons:drop_mortar_shell \
 \
@@ -9014,6 +9020,7 @@ hearth_and_home:black_stained_barred_glass_pane \
 chisel:glasspanedyedblack \
 \
 quark:crystal_pane:variant=crystal_black
+
 
 # Water
 block.32000 = water \

--- a/block.properties
+++ b/block.properties
@@ -9021,7 +9021,6 @@ chisel:glasspanedyedblack \
 \
 quark:crystal_pane:variant=crystal_black
 
-
 # Water
 block.32000 = water \
 \


### PR DESCRIPTION
This adds the following blocks to block.properties:
- chain conveyor
- Item hatch
- Packager and Re-packager
- Package frogport
- Package postbox
- Stock link
- Stock ticker
- Redstone requester
- Factory gauge
- Table cloths and covers
- Desk bell
- Cardboard block
- Cherry and bamboo windows
- Industrial iron window
- Weathered iron block and windows

This also changes the location of a few pre-existing create blocks to better match their default textures, such as brass casings and the brass-encased blocks:
![image](https://github.com/user-attachments/assets/92604606-9e6f-4403-b267-2d89354ea945)

I included changing the location of belts to cover encased belts, but since the type of casing is handled with block entity data and not block state, every cased variant would be the same, which appears fine with vanilla casing, but might not work too well if you were to use an addon that added new casings that could be put on belts, such as encased.
![image](https://github.com/user-attachments/assets/b43cbb8b-e141-40ed-88de-b31e9e5557ab)
![image](https://github.com/user-attachments/assets/5f5f9b01-4c17-4934-95f1-9b65cd0ba71f)


This also contains two entries for empty blaze burners, as apparently older versions of create used a different block id for empty blaze burners and removing it would be removing functionality, so both of them are next to each other.

Some of the locations for certain blocks are my best judgement of where they should go based on other similar existing blocks in the list, whereas some of them are because it looks more visually interesting. These can be changed if needed.