### PR TITLE
Added Ender IO Emmissive Glass Variants

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -9141,6 +9141,8 @@ createframed:framed_radon_lamp_black createframed:framed_radon_lamp_white create
 \
 dimdoors:decayed_block dimdoors:unfolded_block dimdoors:unravelled_block dimdoors:unwarped_block \
 \
+enderio:clear_glass_e_white enderio:clear_glass_ep_white enderio:clear_glass_enp_white enderio:clear_glass_em_white enderio:clear_glass_enm_white enderio:clear_glass_ea_white enderio:clear_glass_ena_white enderio:clear_glass_e_black enderio:clear_glass_ep_black enderio:clear_glass_enp_black enderio:clear_glass_em_black enderio:clear_glass_enm_black enderio:clear_glass_ea_black enderio:clear_glass_ena_black enderio:clear_glass_e_gray enderio:clear_glass_ep_gray enderio:clear_glass_enp_gray enderio:clear_glass_em_gray enderio:clear_glass_enm_gray enderio:clear_glass_ea_gray enderio:clear_glass_ena_gray enderio:clear_glass_e_light_gray enderio:clear_glass_ep_light_gray enderio:clear_glass_enp_light_gray enderio:clear_glass_em_light_gray enderio:clear_glass_enm_light_gray enderio:clear_glass_ea_light_gray enderio:clear_glass_ena_light_gray \
+\
 gtceu:white_lamp:active=true gtceu:white_borderless_lamp:active=true gtceu:light_gray_lamp:active=true gtceu:light_gray_borderless_lamp:active=true gtceu:gray_lamp:active=true gtceu:gray_borderless_lamp:active=true gtceu:black_lamp:active=true gtceu:black_borderless_lamp:active=true gtceu:kanthal_coil_block:active=true gtceu:naquadah_coil_block:active=true \
 \
 gtocore:naquadriatictaranium_coil_block:active=true gtocore:infinity_coil_block:active=true \
@@ -9172,6 +9174,8 @@ betterend:thallasium_bulb_lantern_brown betterend:terminite_bulb_lantern_brown b
 \
 createframed:framed_radon_lamp_brown \
 \
+enderio:clear_glass_e_brown enderio:clear_glass_ep_brown enderio:clear_glass_enp_brown enderio:clear_glass_em_brown enderio:clear_glass_enm_brown enderio:clear_glass_ea_brown enderio:clear_glass_ena_brown \
+\
 gtceu:brown_lamp:active=true gtceu:brown_borderless_lamp:active=true \
 \
 hearth_and_home:brown_paper_lantern \
@@ -9198,6 +9202,8 @@ betterend:thallasium_bulb_lantern_red betterend:terminite_bulb_lantern_red bette
 biomeswevegone:fluorescent_cattail:color=red biomeswevegone:red_glow_bottle biomeswevegone:red_glowcane \
 \
 createframed:framed_radon_lamp_red \
+\
+enderio:clear_glass_e_red enderio:clear_glass_ep_red enderio:clear_glass_enp_red enderio:clear_glass_em_red enderio:clear_glass_enm_red enderio:clear_glass_ea_red enderio:clear_glass_ena_red \
 \
 gtceu:red_lamp:active=true gtceu:red_borderless_lamp:active=true gtceu:tritanium_coil_block:active=true \
 \
@@ -9236,6 +9242,8 @@ caverns_and_chasms:lava_lamp \
 \
 createframed:framed_radon_lamp_orange \
 \
+enderio:clear_glass_e_orange enderio:clear_glass_ep_orange enderio:clear_glass_enp_orange enderio:clear_glass_em_orange enderio:clear_glass_enm_orange enderio:clear_glass_ea_orange enderio:clear_glass_ena_orange \
+\
 gtceu:orange_lamp:active=true gtceu:orange_borderless_lamp:active=true gtceu:cupronickel_coil_block:active=true gtceu:bronze_firebox_casing:active=true gtceu:steel_firebox_casing:active=true gtceu:titanium_firebox_casing:active=true gtceu:tungstensteel_firebox_casing:active=true \
 \
 gtocore:hypogen_coil_block:active=true \
@@ -9269,6 +9277,8 @@ createdeco:yellow_industrial_iron_lamp:lit=true createdeco:yellow_andesite_lamp:
 \
 createframed:framed_radon_lamp_yellow \
 \
+enderio:clear_glass_e_yellow enderio:clear_glass_ep_yellow enderio:clear_glass_enp_yellow enderio:clear_glass_em_yellow enderio:clear_glass_enm_yellow enderio:clear_glass_ea_yellow enderio:clear_glass_ena_yellow \
+\
 gtceu:yellow_lamp:active=true gtceu:yellow_borderless_lamp:active=true \
 \
 gtocore:adamantine_coil_block:active=true \
@@ -9295,6 +9305,8 @@ betterend:thallasium_bulb_lantern_lime betterend:terminite_bulb_lantern_lime bet
 create_enchantment_industry:experience create_enchantment_industry:experience_hatch \
 \
 createframed:framed_radon_lamp_lime \
+\
+enderio:clear_glass_e_lime enderio:clear_glass_ep_lime enderio:clear_glass_enp_lime enderio:clear_glass_em_lime enderio:clear_glass_enm_lime enderio:clear_glass_ea_lime enderio:clear_glass_ena_lime \
 \
 frights_and_foliage:spooky_lantern frights_and_foliage:spooky_campfire frights_and_foliage:spooky_torch \
 \
@@ -9331,6 +9343,8 @@ createdeco:green_industrial_iron_lamp:lit=true createdeco:green_andesite_lamp:li
 \
 createframed:framed_radon_lamp_green \
 \
+enderio:clear_glass_e_green enderio:clear_glass_ep_green enderio:clear_glass_enp_green enderio:clear_glass_em_green enderio:clear_glass_enm_green enderio:clear_glass_ea_green enderio:clear_glass_ena_green \
+\
 gtceu:green_lamp:active=true gtceu:green_borderless_lamp:active=true \
 \
 hearth_and_home:green_paper_lantern \
@@ -9362,6 +9376,8 @@ create_enchantment_industry:super_experience_block \
 \
 createframed:framed_radon_lamp_cyan \
 \
+enderio:clear_glass_e_cyan enderio:clear_glass_ep_cyan enderio:clear_glass_enp_cyan enderio:clear_glass_em_cyan enderio:clear_glass_enm_cyan enderio:clear_glass_ea_cyan enderio:clear_glass_ena_cyan \
+\
 gtceu:cyan_lamp:active=true gtceu:cyan_borderless_lamp:active=true \
 \
 hearth_and_home:cyan_paper_lantern \
@@ -9390,6 +9406,8 @@ another_furniture:light_blue_lamp:lit=true \
 betterend:thallasium_bulb_lantern_light_blue betterend:iron_bulb_lantern_light_blue betterend:terminite_bulb_lantern_light_blue \
 \
 createframed:framed_radon_lamp_light_blue \
+\
+enderio:clear_glass_e_light_blue enderio:clear_glass_ep_light_blue enderio:clear_glass_enp_light_blue enderio:clear_glass_em_light_blue enderio:clear_glass_enm_light_blue enderio:clear_glass_ea_light_blue enderio:clear_glass_ena_light_blue \
 \
 gtceu:light_blue_lamp:active=true gtceu:light_blue_borderless_lamp:active=true \
 \
@@ -9426,6 +9444,8 @@ createdeco:blue_andesite_lamp:lit=true createdeco:blue_brass_lamp:lit=true creat
 \
 createframed:framed_radon_lamp_blue \
 \
+enderio:clear_glass_e_blue enderio:clear_glass_ep_blue enderio:clear_glass_enp_blue enderio:clear_glass_em_blue enderio:clear_glass_enm_blue enderio:clear_glass_ea_blue enderio:clear_glass_ena_blue \
+\
 gtceu:blue_lamp:active=true gtceu:blue_borderless_lamp:active=true gtceu:hssg_coil_block:active=true \
 \
 gtocore:starmetal_coil_block:active=true gtocore:eternity_coil_block:active=true \
@@ -9456,6 +9476,8 @@ ars_nouveau:brazier_relay:lit=true ars_nouveau:ritual_brazier:lit=true ars_nouve
 betterend:thallasium_bulb_lantern_purple betterend:terminite_bulb_lantern_purple betterend:iron_bulb_lantern_purple \
 \
 createframed:framed_radon_lamp_purple \
+\
+enderio:clear_glass_e_purple enderio:clear_glass_ep_purple enderio:clear_glass_enp_purple enderio:clear_glass_em_purple enderio:clear_glass_enm_purple enderio:clear_glass_ea_purple enderio:clear_glass_ena_purple \
 \
 gtceu:purple_lamp:active=true gtceu:purple_borderless_lamp:active=true gtceu:rtm_alloy_coil_block:active=true \
 \
@@ -9489,6 +9511,8 @@ another_furniture:magenta_lamp:lit=true \
 betterend:diorite_lantern betterend:andesite_lantern betterend:end_stone_lantern betterend:quartz_lantern betterend:purpur_lantern betterend:granite_lantern betterend:blackstone_lantern betterend:violecite_lantern betterend:umbralith_lantern betterend:sandy_jadestone_lantern betterend:azure_jadestone_lantern betterend:virid_jadestone_lantern betterend:sulphuric_rock_lantern betterend:flavolite_lantern betterend:thallasium_bulb_lantern_magenta betterend:terminite_bulb_lantern_magenta betterend:iron_bulb_lantern_magenta \
 \
 createframed:framed_radon_lamp_magenta \
+\
+enderio:clear_glass_e_magenta enderio:clear_glass_ep_magenta enderio:clear_glass_enp_magenta enderio:clear_glass_em_magenta enderio:clear_glass_enm_magenta enderio:clear_glass_ea_magenta enderio:clear_glass_ena_magenta \
 \
 gtceu:magenta_lamp:active=true gtceu:magenta_borderless_lamp:active=true gtceu:trinium_coil_block:active=true \
 \
@@ -9524,6 +9548,8 @@ chipped:warped_torch chipped:warped_wall_torch \
 create:rose_quartz_lamp:powering=true create:elevator_contact:powering=true \
 \
 createframed:framed_radon_lamp_pink \
+\
+enderio:clear_glass_e_pink enderio:clear_glass_ep_pink enderio:clear_glass_enp_pink enderio:clear_glass_em_pink enderio:clear_glass_enm_pink enderio:clear_glass_ea_pink enderio:clear_glass_ena_pink \
 \
 gtceu:pink_lamp:active=true gtceu:pink_borderless_lamp:active=true gtceu:nichrome_coil_block:active=true \
 \


### PR DESCRIPTION
All Ender IO Emissive Glass Variants have been added to their respective color in the additional modded color blocks section (Starts roughly line 9100).