### PR TITLE
Added some illuminated spelunkery blocks that should glow

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -6643,7 +6643,11 @@ rechiseled:glowstone_brick_pattern rechiseled:glowstone_brick_pattern_connecting
 \
 securitycraft:reinforced_glowstone \
 \
-torchmaster:feral_flare_lantern torchmaster:invisible_light
+torchmaster:feral_flare_lantern torchmaster:invisible_light \
+\
+spelunkery:rock_salt_block:illuminated=true spelunkery:polished_rock_salt:illuminated=true spelunkery:rock_salt_bricks:illuminated=true spelunkery:rock_salt_slab:illuminated=true spelunkery:rock_salt_stairs:illuminated=true spelunkery:rock_salt_slab:illuminated=true spelunkery:rock_salt_wall:illuminated=true spelunkery:polished_rock_salt_stairs:illuminated=true spelunkery:polished_rock_salt_slab:illuminated=true spelunkery:polished_rock_salt_wall:illuminated=true spelunkery:rock_salt_brick_stairs:illuminated=true spelunkery:rock_salt_brick_slab:illuminated=true spelunkery:rock_salt_brick_wall:illuminated=true
+
+
 
 # Nether Bricks Full Blocks
 block.10416 = nether_bricks cracked_nether_bricks chiseled_nether_bricks \


### PR DESCRIPTION
Rock salt blocks glow when light is adjacent to them, i.e illuminated tag, Carved Nephrite probably could glow too, but I'm unsure how to make sure only partial glow on the block since its charge tag is from 0 to 100