### PR TITLE
Add support for Nature's Spirit "chert" ores

### DIFF
--- a/addedMods.md
+++ b/addedMods.md
@@ -282,7 +282,7 @@ Here we can keep track of what mods has been added and what version a contributo
 | [Mythic Upgrades](https://modrinth.com/mod/mythic-upgrades) | | Partial Support |
 | [Natura](https://www.curseforge.com/minecraft/mc-mods/natura) | 4.3.2.69 | Fully Added |
 | [Naturalist](https://modrinth.com/mod/naturalist) | 4.0.3 | Fully Added |
-| [Nature's Spirit](https://modrinth.com/mod/natures-spirit) | | Foliage Only |
+| [Nature's Spirit](https://modrinth.com/mod/natures-spirit) | | Partial Support|
 | [Neapolitan](https://www.curseforge.com/minecraft/mc-mods/neapolitan) | 5.0.0 | Foliage Only |
 | [Nether Archives](https://modrinth.com/mod/nether-archives) | 0.3.6 | Fully Added |
 | [Nether's Delight](https://modrinth.com/mod/nethers-delight) | | In Testing | # Why is soil in the Deepslate Diamond Ore ID??

--- a/block.properties
+++ b/block.properties
@@ -1136,6 +1136,8 @@ mores:cobalt_ore mores:deepslate_cobalt_ore mores:deepslate_moissanite_ore mores
 \
 mythicmetals:blackstone_stormyx_ore mythicmetals:calcite_kyber_ore mythicmetals:silver_ore mythicmetals:stormyx_ore mythicmetals:tin_ore \
 \
+natures_spirit:chert_iron_ore natures_spirit:chert_copper_ore natures_spirit:chert_gold_ore natures_spirit:chert_redstone_ore natures_spirit:chert_emerald_ore \
+\
 oreganized:deepslate_silver_ore oreganized:raw_silver_block oreganized:silver_ore \
 \
 organics:bone_ore organics:ender_pearl_ore organics:gunpowder_ore organics:quartz_ice_ore \


### PR DESCRIPTION
Somewhat closes #205
There was an issue with glowing ores in Nature's Spirit where the whole ore block was emissive (excluding diamond and lapis). I wouldn't merge unless nothing else works. Should probably include a note somewhere about using the emissive resource pack as in my opinion at least, it looks better.
Without this PR:
![kuva](https://github.com/user-attachments/assets/18fb14c7-6b10-4960-acab-e580cfc4cc22)
Without this PR and with the embedded emissive ore resource pack:
![kuva](https://github.com/user-attachments/assets/82d850da-a968-49fc-b378-6b2fd42973ea)
With this PR:
![kuva](https://github.com/user-attachments/assets/f8b016ce-5ef4-4f04-b93a-234aaae901ff)
With this PR and the embedded emissive ore resource pack:
![kuva](https://github.com/user-attachments/assets/fab7d554-1942-4231-8cd7-1290a4fdf2b9)