### PR TITLE
Ice and Fire blocks

### DIFF
--- a/addedMods.md
+++ b/addedMods.md
@@ -224,6 +224,7 @@ Here we can keep track of what mods have been added and what version a contribut
 | [Hexxit World](https://www.technicpack.net/modpack/hexxit-ii.896745/mods) | 1.1.0-33 | Foliage Only | # Seems like this is the only place that even lists Hexxit World.
 | [HT's TreeChop](https://www.curseforge.com/minecraft/mc-mods/treechop) | 0.14.7 | Fully Added |
 | [Hydrological](https://modrinth.com/mod/hydrological) | | Unknown | # Not even sure if this is the correct mod, ID is hydrol
+| [Ice and Fire](https://modrinth.com/mod/iceandfire-ce) | 1.0.2 | Blocks Only | # Tested using the Community Edition, but IDs should match the original. Items and entities planned. Dread Portals are still invisible but no ID seems to fix them.
 | [iChunUtil](https://www.curseforge.com/minecraft/mc-mods/ichunutil) | 7.2.2 | Fully Added | # There's just a single block??
 | [Illuminations Legacy 🔥](https://www.curseforge.com/minecraft/mc-mods/illuminations-legacy) | 0.4.4-hexxit | Entities Only  | # Can only find this specific edit here?? https://www.technicpack.net/modpack/hexxit-ii.896745/mods
 | [Immersive Aircraft](https://modrinth.com/mod/immersive-aircraft) | | Fully Added |

--- a/block.properties
+++ b/block.properties
@@ -225,6 +225,8 @@ bibliocraft:discrack bibliocraft:framedchest \
 \
 charm:acacia_chest charm:azalea_chest charm:bamboo_chest charm:birch_chest charm:cherry_chest charm:dark_oak_chest charm:jungle_chest charm:mangrove_chest charm:oak_chest charm:spruce_chest \
 \
+iceandfire:ghost_chest iceandfire:podium_oak iceandfire:podium_birch iceandfire:podium_spruce iceandfire:podium_jungle iceandfire:podium_dark_oak iceandfire:podium_acacia iceandfire:desert_myrmex_cocoon iceandfire:jungle_myrmex_cocoon iceandfire:pixie_house_oak iceandfire:pixie_house_birch iceandfire:pixie_house_spruce iceandfire:pixie_house_dark_oak iceandfire:pixie_jar_empty \
+\
 immersiveengineering:watermill immersiveengineering:windmill \
 \
 ironchest:iron_chest \
@@ -279,6 +281,8 @@ enderio:enderman_head enderio:wall_enderman_head \
 gravestone:gravestone \
 \
 growthcraft_milk:churn_plunger \
+\
+iceandfire:pixie_house_mushroom_red iceandfire:pixie_house_mushroom_brown \
 \
 immersiveengineering:shader_banner immersiveengineering:shader_banner_wall \
 \
@@ -393,6 +397,8 @@ flowerpatch:allium_patch flowerpatch:azure_bluet_patch flowerpatch:blue_orchid_p
 friendsandfoes:buttercup \
 \
 hexxitgear:hexbiscus \
+\
+iceandfire:fire_lily iceandfire:frost_lily iceandfire:lightning_lily \
 \
 immersive_weathering:weeds:age=4 immersive_weathering:weeds:age=5 immersive_weathering:weeds:age=6 immersive_weathering:weeds:age=7 \
 \
@@ -536,6 +542,8 @@ herbalbrews:coffee_plant herbalbrews:hibiscus herbalbrews:lavender herbalbrews:r
 \
 hydrol:dry_grass:half=bottom \
 \
+iceandfire:dreadwood_sapling \
+\
 immersive_weathering:dune_grass immersive_weathering:frosty_fern immersive_weathering:frosty_grass immersive_weathering:weeds:age=0 immersive_weathering:weeds:age=1 immersive_weathering:weeds:age=2 immersive_weathering:weeds:age=3 immersive_weathering:wetland_whimsy/bald_cypress_leaf_pile \
 \
 immersiveengineering:hemp:half=lower \
@@ -658,6 +666,8 @@ dynamictrees:acacia_leaves dynamictrees:apple:age=1 dynamictrees:apple:age=2 dyn
 expandeddelight:cinnamon_leaves \
 \
 hydrol:acacia_leaves_pile hydrol:acacia_leaves_wall hydrol:cherry_leaves_pile hydrol:cherry_leaves_wall hydrol:jungle_leaves_pile hydrol:jungle_leaves_wall hydrol:mangrove_leaves_pile hydrol:mangrove_leaves_wall hydrol:spruce_leaves_pile hydrol:spruce_leaves_wall \
+\
+iceandfire:dreadwood_leaves \
 \
 mocreatures:wyvwood_leaves \
 \
@@ -1126,7 +1136,7 @@ expandeddelight:deepslate_salt_ore expandeddelight:salt_ore \
 \
 gravelores:lead_gravel_ore gravelores:nickel_gravel_ore gravelores:silver_gravel_ore gravelores:tin_gravel_ore \
 \
-iceandfire:silver_ore \
+iceandfire:silver_ore iceandfire:deepslate_silver_ore \
 \
 industrialupgrade:apatite/calcium_phosphate industrialupgrade:apatite/fluorapatite industrialupgrade:apatite/nepheline industrialupgrade:apatite/potassium_phosphate industrialupgrade:apatite/sodium_phosphate industrialupgrade:basaltheavyore/alfildit industrialupgrade:basaltheavyore/almenite industrialupgrade:basaltheavyore/azurite industrialupgrade:basaltheavyore/calaverite industrialupgrade:basaltheavyore/euxenite industrialupgrade:basaltheavyore/ferroaugite industrialupgrade:basaltheavyore/galena industrialupgrade:basaltheavyore/magnetite industrialupgrade:basaltheavyore/nickelite industrialupgrade:basaltheavyore/pyrite industrialupgrade:basaltheavyore/quarzite industrialupgrade:basaltheavyore/rhodonite industrialupgrade:basaltheavyore/sheelite industrialupgrade:basaltheavyore/smithsonite industrialupgrade:basaltheavyore/todorokite industrialupgrade:basaltheavyore/uranite industrialupgrade:basaltheavyore1/arsenopyrite industrialupgrade:basaltheavyore1/braggite industrialupgrade:basaltheavyore1/celestine industrialupgrade:basaltheavyore1/coltan industrialupgrade:basaltheavyore1/crocoite industrialupgrade:basaltheavyore1/fergusonite industrialupgrade:basaltheavyore1/germanite industrialupgrade:basaltheavyore1/iridosmine industrialupgrade:basaltheavyore1/tetrahedrite industrialupgrade:basaltheavyore1/theophrastite industrialupgrade:basaltheavyore1/wolframite industrialupgrade:basaltheavyore1/xenotime industrialupgrade:basaltheavyore1/zircon industrialupgrade:baseore/aluminium industrialupgrade:baseore/chromium industrialupgrade:baseore/cobalt industrialupgrade:baseore/germanium industrialupgrade:baseore/iridium industrialupgrade:baseore/magnesium industrialupgrade:baseore/manganese industrialupgrade:baseore/mikhail industrialupgrade:baseore/nickel industrialupgrade:baseore/platinum industrialupgrade:baseore/silver industrialupgrade:baseore/spinel industrialupgrade:baseore/vanadium industrialupgrade:baseore/wolfram industrialupgrade:baseore/zinc industrialupgrade:baseore1/beryllium industrialupgrade:baseore1/cadmium industrialupgrade:baseore1/lithium industrialupgrade:baseore1/osmium industrialupgrade:baseore1/tantalum industrialupgrade:baseore2/arsenic industrialupgrade:baseore2/barium industrialupgrade:baseore2/bismuth industrialupgrade:baseore2/gadolinium industrialupgrade:baseore2/gallium industrialupgrade:baseore2/hafnium industrialupgrade:baseore2/molybdenum industrialupgrade:baseore2/neodymium industrialupgrade:baseore2/niobium industrialupgrade:baseore2/palladium industrialupgrade:baseore2/polonium industrialupgrade:baseore2/strontium industrialupgrade:baseore2/sulfur industrialupgrade:baseore2/thallium industrialupgrade:baseore2/yttrium industrialupgrade:baseore2/zirconium industrialupgrade:blockbasalts/basalt_magma industrialupgrade:blockbasalts/basalt_sulfur_ore industrialupgrade:blockpreciousore/quartz_ore industrialupgrade:blockpreciousore/ruby_ore industrialupgrade:blockpreciousore/sapphire_ore industrialupgrade:blockpreciousore/topaz_ore industrialupgrade:blockradiationore/americium_ore industrialupgrade:blockradiationore/curium_ore industrialupgrade:blockradiationore/neptunium_ore industrialupgrade:classicore/lead industrialupgrade:classicore/tin industrialupgrade:classicore/uranium industrialupgrade:heavyore/alfildit industrialupgrade:heavyore/almenite industrialupgrade:heavyore/azurite industrialupgrade:heavyore/calaverite industrialupgrade:heavyore/euxenite industrialupgrade:heavyore/ferroaugite industrialupgrade:heavyore/galena industrialupgrade:heavyore/magnetite industrialupgrade:heavyore/nickelite industrialupgrade:heavyore/pyrite industrialupgrade:heavyore/quarzite industrialupgrade:heavyore/rhodonite industrialupgrade:heavyore/sheelite industrialupgrade:heavyore/smithsonite industrialupgrade:heavyore/todorokite industrialupgrade:heavyore/uranite industrialupgrade:mineral/arsenopyrite industrialupgrade:mineral/braggite industrialupgrade:mineral/celestine industrialupgrade:mineral/coltan industrialupgrade:mineral/crocoite industrialupgrade:mineral/crystal industrialupgrade:mineral/fergusonite industrialupgrade:mineral/germanite industrialupgrade:mineral/iridosmine industrialupgrade:mineral/tetrahedrite industrialupgrade:mineral/theophrastite industrialupgrade:mineral/wolframite industrialupgrade:mineral/xenotime industrialupgrade:mineral/zircon \
 \
@@ -1252,6 +1262,8 @@ chiselsandbits:chiseled_rock \
 cqrepoured:stone_cube cqrepoured:stone_pillar cqrepoured:stone_scale cqrepoured:stone_small cqrepoured:stone_square \
 \
 deadlyworld:infested_minecraft_stonebrick \
+\
+iceandfire:dragonforge_fire_brick:grill=false iceandfire:dragonforge_ice_brick:grill=false iceandfire:dragonforge_lightning_brick:grill=false iceandfire:dragonforge_fire_input:active=false iceandfire:dragonforge_ice_input:active=false iceandfire:dragonforge_lightning_input:active=false iceandfire:dragonforge_fire_core_disabled iceandfire:dragonforge_ice_core_disabled iceandfire:dragonforge_lightning_core_disabled \
 \
 immersive_weathering:mossy_chiseled_stone_bricks immersive_weathering:sandy_chiseled_stone_bricks immersive_weathering:sandy_stone_bricks immersive_weathering:snowy_chiseled_stone_bricks immersive_weathering:snowy_stone_bricks \
 \
@@ -1441,6 +1453,8 @@ computercraft:lectern \
 \
 create:lectern_controller \
 \
+iceandfire:lectern \
+\
 securitycraft:reinforced_lectern
 
 # Still Lava - Euphoria Patches Lava Noise
@@ -1543,6 +1557,8 @@ extshape:smooth_stone_slab_double \
 fossilslegacy:fossil_ore \
 \
 hearth_and_home:black_tiles hearth_and_home:blue_tiles hearth_and_home:brown_tiles hearth_and_home:cyan_tiles hearth_and_home:gray_tiles hearth_and_home:green_tiles hearth_and_home:light_blue_tiles hearth_and_home:light_gray_tiles hearth_and_home:lime_tiles hearth_and_home:magenta_tiles hearth_and_home:orange_tiles hearth_and_home:pink_tiles hearth_and_home:purple_tiles hearth_and_home:red_tiles hearth_and_home:stone_column hearth_and_home:tiles hearth_and_home:white_tiles hearth_and_home:yellow_tiles \
+\
+iceandfire:chared_stone iceandfire:crackled_stone \
 \
 immersive_weathering:mossy_stone immersive_weathering:sandy_stone immersive_weathering:snowy_stone \
 \
@@ -2368,6 +2384,8 @@ farm_and_charm:fertilized_soil \
 \
 farmersdelight:organic_compost farmersdelight:rich_soil \
 \
+iceandfire:chared_dirt iceandfire:crackled_dirt iceandfire:myrmex_resin_jungle iceandfire:graveyard_soil \
+\
 immersive_weathering:earthen_clay:waterlogged=false immersive_weathering:loam immersive_weathering:nulch_block:molten=false immersive_weathering:permafrost immersive_weathering:sandy_dirt immersive_weathering:silt \
 \
 mcwpaths:dirt_path_block:flattened=false mcwpaths:podzol_path_block:flattened=false \
@@ -2427,6 +2445,8 @@ biomeswevegone:lush_grass_block:snowy=false biomeswevegone:overgrown_dacite:snow
 blockus:legacy_first_grass_block blockus:legacy_grass_block \
 \
 dynamictrees:rooty_grass_block \
+\
+iceandfire:chared_grass iceandfire:crackled_grass iceandfire:myrmex_resin_sticky_jungle \
 \
 immersive_weathering:grassy_earthen_clay:snowy=false:waterlogged=false immersive_weathering:grassy_permafrost immersive_weathering:grassy_sandy_dirt:snowy=false immersive_weathering:grassy_silt:snowy=false immersive_weathering:rooted_grass_block:snowy=false \
 \
@@ -2607,6 +2627,8 @@ enderio:primitive_alloy_smelter \
 exdeorum:compressed_cobblestone \
 \
 hearth_and_home:cobblestone_bricks \
+\
+iceandfire:chared_cobblestone iceandfire:crackled_cobblestone \
 \
 immersive_weathering:sandy_cobblestone immersive_weathering:snowy_cobblestone \
 \
@@ -2843,6 +2865,8 @@ handcrafted:oak_bench handcrafted:oak_chair handcrafted:oak_corner_trim handcraf
 hearth_and_home:oak_lattice \
 \
 hydrol:oak_wood_wall \
+\
+iceandfire:burnt_torch iceandfire:burnt_torch_wall \
 \
 mca:wooden_slanted_headstone mca:wooden_upright_headstone \
 \
@@ -3839,6 +3863,8 @@ grapplemod:blueprint_shelf grapplemod:modification_table \
 \
 hearth_and_home:dark_oak_parquet hearth_and_home:dark_oak_sanded_wood hearth_and_home:dark_oak_trim hearth_and_home:dark_oak_vertical_trim \
 \
+iceandfire:dreadwood_planks iceandfire:dreadwood_planks_lock \
+\
 immersiveengineering:basic_engineering immersiveengineering:treated_wood_horizontal immersiveengineering:treated_wood_packaged immersiveengineering:treated_wood_vertical immersiveengineering:wooden_barrel \
 \
 lolmct:dark_oak_crafting_table \
@@ -3982,6 +4008,8 @@ chipped:bundled_dark_oak_log chipped:center_cut_dark_oak_log chipped:damaged_dar
 dynamictrees:dark_oak_branch:radius=8 dynamictrees:dark_oak_root:radius=8 \
 \
 fossilslegacy:sigillaria_log fossilslegacy:sigillaria_wood \
+\
+iceandfire:dreadwood_log \
 \
 natura:nether_logs:type=fusewood natura:overworld_logs2:type=sakura natura:overworld_logs2:type=willow \
 \
@@ -4588,6 +4616,8 @@ dynamictrees:rooty_sand \
 \
 exdeorum:compressed_sand \
 \
+iceandfire:myrmex_resin_desert \
+\
 immersiveengineering:grit_sand \
 \
 mcwpaths:sand_path_block:flattened=false \
@@ -4641,6 +4671,8 @@ blockus:redstone_sand \
 chipped:lush_red_sand chipped:wet_red_sand \
 \
 dynamictrees:rooty_red_sand \
+\
+iceandfire:myrmex_resin_sticky_desert \
 \
 mcwpaths:red_sand_path_block:flattened=false \
 \
@@ -4824,6 +4856,8 @@ create:industrial_iron_block create:shadow_steel_casing \
 \
 diagonalwalls:blockus/netherite_brick_wall \
 \
+iceandfire:dragonsteel_fire_block iceandfire:dragonsteel_lightning_block \
+\
 immersiveengineering:coil_hv \
 \
 ironchests:netherite_barrel \
@@ -4961,6 +4995,8 @@ fossilslegacy:analyzer fossilslegacy:feeder \
 \
 functionalstorage:armory_cabinet functionalstorage:compacting_drawer functionalstorage:controller_extension functionalstorage:fluid_1 functionalstorage:fluid_2 functionalstorage:fluid_4 functionalstorage:simple_compacting_drawer functionalstorage:storage_controller \
 \
+iceandfire:dragonsteel_ice_block iceandfire:silver_block iceandfire:raw_silver_block iceandfire:silver_pile:layers=8 \
+\
 immersive_weathering:cut_iron immersive_weathering:exposed_cut_iron immersive_weathering:exposed_plate_iron immersive_weathering:plate_iron immersive_weathering:rusted_cut_iron immersive_weathering:rusted_plate_iron immersive_weathering:waxed_cut_iron immersive_weathering:waxed_exposed_cut_iron immersive_weathering:waxed_exposed_plate_iron immersive_weathering:waxed_plate_iron immersive_weathering:waxed_rusted_cut_iron immersive_weathering:waxed_rusted_plate_iron immersive_weathering:waxed_weathered_cut_iron immersive_weathering:waxed_weathered_plate_iron immersive_weathering:weathered_cut_iron immersive_weathering:weathered_plate_iron \
 \
 immersiveengineering:fluid_sorter immersiveengineering:furnace_heater immersiveengineering:metal_barrel immersiveengineering:sheetmetal_aluminum immersiveengineering:sheetmetal_iron immersiveengineering:sheetmetal_nickel immersiveengineering:sheetmetal_silver immersiveengineering:storage_aluminum immersiveengineering:storage_nickel immersiveengineering:storage_silver \
@@ -5065,6 +5101,8 @@ fairylights:fastener \
 farm_and_charm:mincer \
 \
 fossilslegacy:gene_modification_table fossilslegacy:iron_llama_statue \
+\
+iceandfire:silver_pile:layers=1 iceandfire:silver_pile:layers=2 iceandfire:silver_pile:layers=3 iceandfire:silver_pile:layers=4 iceandfire:silver_pile:layers=5 iceandfire:silver_pile:layers=6 iceandfire:silver_pile:layers=7 \
 \
 immersive_weathering:cut_iron_slab immersive_weathering:cut_iron_stairs immersive_weathering:exposed_cut_iron_slab immersive_weathering:exposed_cut_iron_stairs immersive_weathering:exposed_plate_iron_slab immersive_weathering:exposed_plate_iron_stairs immersive_weathering:plate_iron_slab immersive_weathering:plate_iron_stairs immersive_weathering:rusted_cut_iron_slab immersive_weathering:rusted_cut_iron_stairs immersive_weathering:rusted_plate_iron_slab immersive_weathering:rusted_plate_iron_stairs immersive_weathering:waxed_cut_iron_slab immersive_weathering:waxed_cut_iron_stairs immersive_weathering:waxed_exposed_cut_iron_slab immersive_weathering:waxed_exposed_cut_iron_stairs immersive_weathering:waxed_exposed_plate_iron_slab immersive_weathering:waxed_exposed_plate_iron_stairs immersive_weathering:waxed_plate_iron_slab immersive_weathering:waxed_plate_iron_stairs immersive_weathering:waxed_rusted_cut_iron_slab immersive_weathering:waxed_rusted_cut_iron_stairs immersive_weathering:waxed_rusted_plate_iron_slab immersive_weathering:waxed_rusted_plate_iron_stairs immersive_weathering:waxed_weathered_cut_iron_slab immersive_weathering:waxed_weathered_cut_iron_stairs immersive_weathering:waxed_weathered_plate_iron_slab immersive_weathering:waxed_weathered_plate_iron_stairs immersive_weathering:weathered_cut_iron_slab immersive_weathering:weathered_cut_iron_stairs immersive_weathering:weathered_plate_iron_slab immersive_weathering:weathered_plate_iron_stairs \
 \
@@ -5280,6 +5318,8 @@ enderio:copper_alloy_block enderio:energetic_alloy_block \
 \
 farm_and_charm:silo_copper \
 \
+iceandfire:copper_pile:layers=8 \
+\
 immersiveengineering:coil_lv immersiveengineering:dynamo immersiveengineering:electromagnet immersiveengineering:generator immersiveengineering:heavy_engineering immersiveengineering:light_engineering immersiveengineering:sheetmetal_constantan immersiveengineering:sheetmetal_copper immersiveengineering:storage_constantan immersiveengineering:thermoelectric_generator immersiveengineering:turntable \
 \
 ironchests:copper_barrel \
@@ -5346,6 +5386,8 @@ extshape:copper_button extshape:copper_fence extshape:copper_fence_gate extshape
 fossilslegacy:copper_llama_statue fossilslegacy:exposed_copper_llama_statue fossilslegacy:oxidized_copper_llama_statue fossilslegacy:waxed_copper_llama_statue fossilslegacy:waxed_exposed_copper_llama_statue fossilslegacy:waxed_oxidized_copper_llama_statue fossilslegacy:waxed_weathered_copper_llama_statue fossilslegacy:weathered_copper_llama_statue \
 \
 friendsandfoes:copper_button friendsandfoes:exposed_copper_button friendsandfoes:exposed_lightning_rod friendsandfoes:oxidized_copper_button friendsandfoes:oxidized_lightning_rod friendsandfoes:waxed_copper_button friendsandfoes:waxed_exposed_copper_button friendsandfoes:waxed_exposed_lightning_rod friendsandfoes:waxed_lightning_rod friendsandfoes:waxed_oxidized_copper_button friendsandfoes:waxed_oxidized_lightning_rod friendsandfoes:waxed_weathered_copper_button friendsandfoes:waxed_weathered_lightning_rod friendsandfoes:weathered_copper_button friendsandfoes:weathered_lightning_rod \
+\
+iceandfire:copper_pile:layers=1 iceandfire:copper_pile:layers=2 iceandfire:copper_pile:layers=3 iceandfire:copper_pile:layers=4 iceandfire:copper_pile:layers=5 iceandfire:copper_pile:layers=6 iceandfire:copper_pile:layers=7 \
 \
 immersiveengineering:breaker_switch immersiveengineering:cagelamp:active=false immersiveengineering:charging_station immersiveengineering:chute_copper immersiveengineering:conveyor_basic immersiveengineering:conveyor_dropper immersiveengineering:conveyor_extract immersiveengineering:conveyor_splitter immersiveengineering:conveyor_vertical immersiveengineering:lightning_rod immersiveengineering:metal_press immersiveengineering:mixer immersiveengineering:refinery immersiveengineering:slab_sheetmetal_constantan immersiveengineering:slab_sheetmetal_copper immersiveengineering:slab_storage_constantan \
 \
@@ -5574,6 +5616,8 @@ createaddition:digital_adapter createaddition:electrum_block \
 \
 handcrafted:golden_medium_pot handcrafted:golden_thick_pot handcrafted:golden_thin_pot handcrafted:golden_wide_pot handcrafted:yellow_bowl handcrafted:yellow_crockery_combo handcrafted:yellow_cup handcrafted:yellow_plate \
 \
+iceandfire:gold_pile:layers=8 \
+\
 immersiveengineering:coil_mv immersiveengineering:sheetmetal_electrum immersiveengineering:sheetmetal_gold immersiveengineering:storage_electrum \
 \
 ironchests:gold_barrel \
@@ -5643,6 +5687,8 @@ extshape:gold_button extshape:gold_fence extshape:gold_fence_gate extshape:gold_
 \
 extshape_blockus:gold_brick_quarter_piece extshape_blockus:gold_brick_vertical_quarter_piece extshape_blockus:gold_brick_vertical_slab extshape_blockus:gold_brick_vertical_stairs extshape_blockus:gold_plating_pressure_plate extshape_blockus:gold_plating_quarter_piece extshape_blockus:gold_plating_vertical_quarter_piece extshape_blockus:gold_plating_vertical_slab extshape_blockus:gold_plating_vertical_stairs extshape_blockus:gold_plating_wall \
 \
+iceandfire:gold_pile:layers=1 iceandfire:gold_pile:layers=2 iceandfire:gold_pile:layers=3 iceandfire:gold_pile:layers=4 iceandfire:gold_pile:layers=5 iceandfire:gold_pile:layers=6 iceandfire:gold_pile:layers=7 \
+\
 immersive_weathering:fulgurite \
 \
 immersiveengineering:slab_sheetmetal_electrum immersiveengineering:slab_sheetmetal_gold immersiveengineering:slab_storage_electrum immersiveengineering:tesla_coil immersiveengineering:warning_sign_arrow_double_down immersiveengineering:warning_sign_arrow_double_left immersiveengineering:warning_sign_arrow_double_right immersiveengineering:warning_sign_arrow_double_up immersiveengineering:warning_sign_arrow_down immersiveengineering:warning_sign_arrow_left immersiveengineering:warning_sign_arrow_right immersiveengineering:warning_sign_arrow_up immersiveengineering:warning_sign_attention immersiveengineering:warning_sign_cat immersiveengineering:warning_sign_cold immersiveengineering:warning_sign_creeper immersiveengineering:warning_sign_ear_defenders immersiveengineering:warning_sign_electric immersiveengineering:warning_sign_falling immersiveengineering:warning_sign_fire immersiveengineering:warning_sign_hot immersiveengineering:warning_sign_magnet immersiveengineering:warning_sign_shrieker immersiveengineering:warning_sign_sound immersiveengineering:warning_sign_turret immersiveengineering:warning_sign_villager immersiveengineering:warning_sign_warden \
@@ -5692,6 +5738,8 @@ chisel:bismuth chisel:bismuth/diamond_block chisel:blockcobalt chisel:blockplati
 createutilities:void_steel_block \
 \
 etcetera:bismuth_block \
+\
+iceandfire:sapphire_block \
 \
 ironchests:diamond_barrel \
 \
@@ -5880,6 +5928,8 @@ extendedae:entro_block extendedae:entro_budding_fully extendedae:entro_budding_h
 galosphere:allurite_block galosphere:allurite_brick_slab galosphere:allurite_brick_stairs galosphere:allurite_bricks galosphere:allurite_slab galosphere:allurite_stairs galosphere:amethyst_brick_slab galosphere:amethyst_brick_stairs galosphere:amethyst_bricks galosphere:amethyst_slab galosphere:amethyst_stairs galosphere:chiseled_allurite galosphere:chiseled_amethyst galosphere:chiseled_lumiere galosphere:lumiere_block galosphere:lumiere_brick_slab galosphere:lumiere_brick_stairs galosphere:lumiere_bricks galosphere:lumiere_slab galosphere:lumiere_stairs galosphere:smooth_allurite galosphere:smooth_allurite_slab galosphere:smooth_allurite_stairs galosphere:smooth_amethyst galosphere:smooth_amethyst_slab galosphere:smooth_amethyst_stairs galosphere:smooth_lumiere galosphere:smooth_lumiere_slab galosphere:smooth_lumiere_stairs \
 \
 geode_plus:celestite_block geode_plus:lapis_cluster_block geode_plus:pink_topaz_block \
+\
+iceandfire:dragonforge_lightning_brick:grill=true iceandfire:dragonforge_lightning_input:active=true \
 \
 malum:block_of_mnemonic_fragment malum:block_of_null_slate \
 \
@@ -6167,6 +6217,8 @@ extendedae:crystal_fixer:powered=true extendedae:ex_io_port:powered=true extende
 geode_plus:budding_deepslate_lapis geode_plus:budding_lapis geode_plus:budding_sculk_lapis geode_plus:echo_crystal geode_plus:large_echo_bud \
 \
 gravelores:lapis_gravel_ore \
+\
+iceandfire:sapphire_ore \
 \
 inversia:cryo_fire \
 \
@@ -6571,6 +6623,8 @@ ecologics:ice_bricks \
 \
 frostiful:cut_packed_ice frostiful:ice_pane \
 \
+iceandfire:frozen_dirt iceandfire:frozen_grass iceandfire:frozen_stone iceandfire:frozen_cobblestone iceandfire:frozen_gravel iceandfire:dragon_ice iceandfire:frozen_splinters \
+\
 mod_lavacow:ectoplasm_block \
 \
 pvj:ice_formation \
@@ -6599,6 +6653,8 @@ extshape_blockus:ice_brick_fence extshape_blockus:ice_brick_fence_gate extshape_
 fossilslegacy:iced_stone \
 \
 frostiful:cut_packed_ice_slab frostiful:cut_packed_ice_stairs frostiful:cut_packed_ice_wall \
+\
+iceandfire:frozen_dirt_path iceandfire:dragon_ice_spikes \
 \
 immersive_weathering:icicle \
 \
@@ -7258,6 +7314,8 @@ chisel:lavastone chisel:lavastone1 chisel:lavastone2 \
 \
 diagonalwalls:blockus/blaze_brick_wall diagonalwalls:blockus/magma_brick_wall diagonalwalls:blockus/netherrack_brick_wall diagonalwalls:blockus/small_magma_brick_wall \
 \
+iceandfire:dragonforge_fire_brick:grill=true iceandfire:dragonforge_fire_input:active=true \
+\
 immersive_weathering:nulch_block:molten=true \
 \
 mocreatures:firestone \
@@ -7294,6 +7352,8 @@ chisel:array/black_concrete chisel:array/blue_concrete chisel:array/brown_concre
 exdeorum:porcelain_crucible \
 \
 extendedae:ingredient_buffer \
+\
+iceandfire:sea_serpent_scale_block_teal iceandfire:sea_serpent_scale_block_blue iceandfire:sea_serpent_scale_block_deepblue iceandfire:sea_serpent_scale_block_purple iceandfire:sea_serpent_scale_block_green iceandfire:sea_serpent_scale_block_bronze iceandfire:sea_serpent_scale_block_red \
 \
 immersiveengineering:concrete immersiveengineering:concrete_brick immersiveengineering:concrete_brick_cracked immersiveengineering:concrete_chiseled immersiveengineering:concrete_leaded immersiveengineering:concrete_pillar immersiveengineering:concrete_reinforced immersiveengineering:concrete_reinforced_tile immersiveengineering:concrete_tile \
 \
@@ -7336,6 +7396,8 @@ chipped:ash_sand chipped:desert_sand chipped:kelp_sand chipped:overgrown_sand \
 \
 cinderscapes:ash_block \
 \
+iceandfire:dragonscale_red iceandfire:dragonscale_green iceandfire:dragonscale_bronze iceandfire:dragonscale_gray iceandfire:dragonscale_blue iceandfire:dragonscale_white iceandfire:dragonscale_sapphire iceandfire:dragonscale_silver iceandfire:dragonscale_electric iceandfire:dragonscale_amethyst iceandfire:dragonscale_copper iceandfire:dragonscale_black \
+\
 more_slabs_stairs_and_walls:black_concrete_powder_slab more_slabs_stairs_and_walls:black_concrete_powder_stairs more_slabs_stairs_and_walls:black_concrete_powder_wall more_slabs_stairs_and_walls:blue_concrete_powder_slab more_slabs_stairs_and_walls:blue_concrete_powder_stairs more_slabs_stairs_and_walls:blue_concrete_powder_wall more_slabs_stairs_and_walls:brown_concrete_powder_slab more_slabs_stairs_and_walls:brown_concrete_powder_stairs more_slabs_stairs_and_walls:brown_concrete_powder_wall more_slabs_stairs_and_walls:cyan_concrete_powder_slab more_slabs_stairs_and_walls:cyan_concrete_powder_stairs more_slabs_stairs_and_walls:cyan_concrete_powder_wall more_slabs_stairs_and_walls:gray_concrete_powder_slab more_slabs_stairs_and_walls:gray_concrete_powder_stairs more_slabs_stairs_and_walls:gray_concrete_powder_wall more_slabs_stairs_and_walls:green_concrete_powder_slab more_slabs_stairs_and_walls:green_concrete_powder_stairs more_slabs_stairs_and_walls:green_concrete_powder_wall more_slabs_stairs_and_walls:light_blue_concrete_powder_slab more_slabs_stairs_and_walls:light_blue_concrete_powder_stairs more_slabs_stairs_and_walls:light_blue_concrete_powder_wall more_slabs_stairs_and_walls:light_gray_concrete_powder_slab more_slabs_stairs_and_walls:light_gray_concrete_powder_stairs more_slabs_stairs_and_walls:light_gray_concrete_powder_wall more_slabs_stairs_and_walls:lime_concrete_powder_slab more_slabs_stairs_and_walls:lime_concrete_powder_stairs more_slabs_stairs_and_walls:lime_concrete_powder_wall more_slabs_stairs_and_walls:magenta_concrete_powder_slab more_slabs_stairs_and_walls:magenta_concrete_powder_stairs more_slabs_stairs_and_walls:magenta_concrete_powder_wall more_slabs_stairs_and_walls:orange_concrete_powder_slab more_slabs_stairs_and_walls:orange_concrete_powder_stairs more_slabs_stairs_and_walls:orange_concrete_powder_wall more_slabs_stairs_and_walls:pink_concrete_powder_slab more_slabs_stairs_and_walls:pink_concrete_powder_stairs more_slabs_stairs_and_walls:pink_concrete_powder_wall more_slabs_stairs_and_walls:purple_concrete_powder_slab more_slabs_stairs_and_walls:purple_concrete_powder_stairs more_slabs_stairs_and_walls:purple_concrete_powder_wall more_slabs_stairs_and_walls:red_concrete_powder_slab more_slabs_stairs_and_walls:red_concrete_powder_stairs more_slabs_stairs_and_walls:red_concrete_powder_wall more_slabs_stairs_and_walls:white_concrete_powder_slab more_slabs_stairs_and_walls:white_concrete_powder_stairs more_slabs_stairs_and_walls:white_concrete_powder_wall more_slabs_stairs_and_walls:yellow_concrete_powder_slab more_slabs_stairs_and_walls:yellow_concrete_powder_stairs more_slabs_stairs_and_walls:yellow_concrete_powder_wall \
 \
 supplementaries:fodder
@@ -7374,6 +7436,8 @@ chipped:angry_crying_obsidian chipped:blank_crying_obsidian_carving chipped:bord
 chisel:energizedvoidstone chisel:voidstone chisel:voidstonerunic \
 \
 frame_changer:crying_chiseled_obsidian frame_changer:crying_obsidian_bricks frame_changer:crying_obsidian_pillar frame_changer:crying_polished_obsidian \
+\
+iceandfire:dragonforge_lightning_core \
 \
 infinite_abyss:deep_amethyst_crystal infinite_abyss:deep_amethyst_crystal_2 \
 \
@@ -7435,6 +7499,8 @@ chipped:angry_blackstone chipped:blackstone_mini_tiles chipped:blackstone_pillar
 \
 exdeorum:crushed_blackstone \
 \
+iceandfire:dread_stone iceandfire:dread_stone_bricks iceandfire:dread_stone_bricks_chiseled iceandfire:dread_stone_bricks_cracked iceandfire:dread_stone_bricks_mossy iceandfire:dread_stone_tile iceandfire:dread_stone_face \
+\
 mcwpaths:blackstone_crystal_floor mcwpaths:blackstone_flagstone mcwpaths:blackstone_running_bond mcwpaths:blackstone_windmill_weave \
 \
 quark:basalt quark:biotite_block quark:biotite_slab_double quark:stone_basalt_bricks_slab_double quark:stone_basalt_slab_double quark:world_stone_bricks:variant=stone_basalt_bricks quark:world_stone_carved:variant=stone_basalt_carved quark:world_stone_pavement:variant=stone_basalt_pavement \
@@ -7481,6 +7547,8 @@ extshape_blockus:blackstone_circular_paving_pressure_plate extshape_blockus:blac
 handcrafted:blackstone_corner_trim handcrafted:blackstone_pillar_trim \
 \
 hearth_and_home:blackstone_chimney:lit=false hearth_and_home:blackstone_chimney:top=false hearth_and_home:polished_blackstone_brick_chimney:lit=false hearth_and_home:polished_blackstone_brick_chimney:top=false hearth_and_home:polished_blackstone_chimney:lit=false hearth_and_home:polished_blackstone_chimney:top=false \
+\
+iceandfire:dread_stone_stairs iceandfire:dread_stone_slab \
 \
 immersive_weathering:cracked_polished_blackstone_brick_slab immersive_weathering:cracked_polished_blackstone_brick_stairs immersive_weathering:cracked_polished_blackstone_brick_wall \
 \
@@ -7572,6 +7640,8 @@ biomeswevegone:lush_dirt_path biomeswevegone:sandy_dirt_path \
 blockus:path \
 \
 environmental:mycelium_path \
+\
+iceandfire:chared_dirt_path iceandfire:crackled_dirt_path \
 \
 mcwpaths:dirt_path_block:flattened=true mcwpaths:podzol_path_block:flattened=true \
 \
@@ -7754,6 +7824,8 @@ etcetera:squid_lamp:waterlogged=true etcetera:wall_squid_lamp:waterlogged=true \
 galosphere:glow_ink_clumps \
 \
 gardens_of_the_dead:glowing_soul_spore \
+\
+iceandfire:dread_torch iceandfire:dread_torch_wall \
 \
 infinitybuttons:soul_torch_button infinitybuttons:soul_torch_lever infinitybuttons:soul_wall_torch_button infinitybuttons:soul_wall_torch_lever \
 \
@@ -7988,6 +8060,8 @@ decorative_blocks:soul_brazier:lit=true \
 diagonalwindows:quark/indigo_corundum_pane \
 \
 galosphere:allurite_cluster galosphere:glinted_allurite_cluster \
+\
+iceandfire:dragonforge_ice_core iceandfire:dragonforge_ice_brick:grill=true iceandfire:dragonforge_ice_input:active=true iceandfire:dread_spawner iceandfire:pixie_jar_2 \
 \
 infinitybuttons:soul_lantern_button infinitybuttons:soul_lantern_lever \
 \
@@ -8274,6 +8348,8 @@ block.10629 = cave_vines_plant:berries=false cave_vines:berries=false \
 \
 deeperdarker:glowing_vines_plant:berries=false \
 \
+iceandfire:myrmex_desert_biolight iceandfire:myrmex_jungle_biolight \
+\
 quark:roots quark:roots_black_flower quark:roots_blue_flower quark:roots_white_flower
 
 # Cave Vines Berries True
@@ -8382,6 +8458,8 @@ chipped:broken_shroomlight chipped:cracked_shroomlight chipped:double_inlayed_sh
 createmetallurgy:brown_light_bulb:level=1 createmetallurgy:brown_light_bulb:level=10 createmetallurgy:brown_light_bulb:level=11 createmetallurgy:brown_light_bulb:level=12 createmetallurgy:brown_light_bulb:level=13 createmetallurgy:brown_light_bulb:level=14 createmetallurgy:brown_light_bulb:level=15 createmetallurgy:brown_light_bulb:level=2 createmetallurgy:brown_light_bulb:level=3 createmetallurgy:brown_light_bulb:level=4 createmetallurgy:brown_light_bulb:level=5 createmetallurgy:brown_light_bulb:level=6 createmetallurgy:brown_light_bulb:level=7 createmetallurgy:brown_light_bulb:level=8 createmetallurgy:brown_light_bulb:level=9 createmetallurgy:orange_light_bulb:level=1 createmetallurgy:orange_light_bulb:level=10 createmetallurgy:orange_light_bulb:level=11 createmetallurgy:orange_light_bulb:level=12 createmetallurgy:orange_light_bulb:level=13 createmetallurgy:orange_light_bulb:level=14 createmetallurgy:orange_light_bulb:level=15 createmetallurgy:orange_light_bulb:level=2 createmetallurgy:orange_light_bulb:level=3 createmetallurgy:orange_light_bulb:level=4 createmetallurgy:orange_light_bulb:level=5 createmetallurgy:orange_light_bulb:level=6 createmetallurgy:orange_light_bulb:level=7 createmetallurgy:orange_light_bulb:level=8 createmetallurgy:orange_light_bulb:level=9 \
 \
 diagonalwindows:quark/orange_corundum_pane \
+\
+iceandfire:dragonforge_fire_core \
 \
 luminous_nether:fungirracklamporange \
 \
@@ -8504,6 +8582,8 @@ createframed:black_cardboard_block createframed:blue_cardboard_block createframe
 \
 farmersdelight:tatami \
 \
+iceandfire:ash \
+\
 immersive_weathering:charred_log:smoldering=false immersive_weathering:charred_planks:smoldering=false \
 \
 immersiveengineering:cushion \
@@ -8592,6 +8672,8 @@ chipped:cracked_bone_block chipped:crunched_bone_block chipped:dark_bone_block c
 \
 fossilslegacy:skull_block \
 \
+iceandfire:dragon_bone_block \
+\
 malum:block_of_grim_talc \
 \
 rechiseled:bone_block_bordered rechiseled:bone_block_bordered_connecting rechiseled:bone_block_bundled rechiseled:bone_block_chiseled rechiseled:bone_block_chiseled_connecting rechiseled:bone_block_connecting_connecting rechiseled:bone_block_cracked rechiseled:bone_block_decorated rechiseled:bone_block_decorated_bordered rechiseled:bone_block_decorated_bordered_connecting rechiseled:bone_block_inverted_tiles rechiseled:bone_block_inverted_tiles_connecting rechiseled:bone_block_patterned rechiseled:bone_block_patterned_connecting rechiseled:bone_block_pillar rechiseled:bone_block_pillar_connecting rechiseled:bone_block_rib rechiseled:bone_block_skull rechiseled:bone_block_smooth \
@@ -8606,6 +8688,8 @@ additionallanterns:bone_chain \
 born_in_chaos_v1:gnawed_bones born_in_chaos_v1:nightmare_stalker_skull \
 \
 butcher:bat_skeleton butcher:chicken_corpse_skeleton butcher:cow_bones butcher:dolphinskeleton butcher:fox_skeleton butcher:goat_corpse_skeleton butcher:goatbones butcher:hanging_bat_skeleton butcher:hanging_chicken_skeleton butcher:hanging_dolphinskeleton butcher:hanging_fox_skeleton butcher:hanging_goat_skeleton butcher:hanging_hoglin_skeleton butcher:hanging_llama_skeleton butcher:hanging_pandaskeleton butcher:hanging_pig_skeleton butcher:hanging_rabbit_skeleton butcher:hanging_sheep_skeleton butcher:hanging_villager_skeleton butcher:hangingpolarbearskeleton butcher:hoglin_skeleton butcher:llama_skeleton butcher:pandaskeleton butcher:pig_bones butcher:pig_corpse_skeleton butcher:pig_skeleton butcher:polarbearskeleton butcher:rabbit_skeleton butcher:sheep_bones butcher:sheep_skeleton_corpse butcher:sheepbones butcher:skeleton_cow_corpse butcher:skeleton_hanging_cow butcher:villager_skeleton \
+\
+iceandfire:dragon_bone_wall \
 \
 placeableitems:block_bone \
 \
@@ -8681,6 +8765,8 @@ extshape:ochre_froglight_button extshape:ochre_froglight_fence extshape:ochre_fr
 \
 galosphere:lumiere_lamp \
 \
+iceandfire:pixie_jar_4 \
+\
 inversia:ochre_selenite \
 \
 luminax:yellow_block luminax:yellow_button luminax:yellow_pressure_plate luminax:yellow_slab luminax:yellow_stairs luminax:yellow_wall \
@@ -8721,6 +8807,8 @@ diagonalwalls:extshape/verdant_froglight_wall \
 diagonalwindows:quark/green_corundum_pane \
 \
 extshape:verdant_froglight_button extshape:verdant_froglight_fence extshape:verdant_froglight_fence_gate extshape:verdant_froglight_pressure_plate extshape:verdant_froglight_quarter_piece extshape:verdant_froglight_slab extshape:verdant_froglight_stairs extshape:verdant_froglight_vertical_quarter_piece extshape:verdant_froglight_vertical_slab extshape:verdant_froglight_vertical_stairs extshape:verdant_froglight_wall \
+\
+iceandfire:pixie_jar_3 \
 \
 infinite_abyss:large_glowing_mushroom \
 \
@@ -8774,6 +8862,8 @@ extshape:pearlescent_froglight_button extshape:pearlescent_froglight_fence extsh
 galosphere:amethyst_lamp \
 \
 geode_plus:budding_pink_topaz \
+\
+iceandfire:pixie_jar_0 iceandfire:pixie_jar_1 \
 \
 infinite_abyss:glowing_pink_crystal infinite_abyss:large_glowing_mushroom_pink infinite_abyss:pink_glowing_crystal infinite_abyss:small_fairy_mushroom \
 \
@@ -8963,6 +9053,8 @@ dynamictrees:rooty_gravel \
 exdeorum:compressed_gravel \
 \
 gravelores:coal_gravel_ore \
+\
+iceandfire:chared_gravel iceandfire:crackled_gravel \
 \
 immersiveengineering:slag_gravel \
 \
@@ -9653,6 +9745,8 @@ farm_and_charm:barley_ball farm_and_charm:oat_ball \
 farmersdelight:rice_bale farmersdelight:straw_bale \
 \
 hearth_and_home:thatch \
+\
+iceandfire:nest \
 \
 quark:thatch quark:thatch_slab_double \
 \
@@ -10916,6 +11010,8 @@ block.30012 = slime_block \
 \
 automobility:launch_gel \
 \
+iceandfire:myrmex_jungle_resin_block \
+\
 quark:color_slime \
 \
 tconstruct:blood_slime tconstruct:ender_slime tconstruct:ichor_slime tconstruct:sky_slime tconstruct:slime tconstruct:slimesteel_block
@@ -10923,7 +11019,9 @@ tconstruct:blood_slime tconstruct:ender_slime tconstruct:ichor_slime tconstruct:
 # Honey Block
 block.30016 = honey_block \
 \
-allthecompressed:honey_block_1x allthecompressed:honey_block_2x allthecompressed:honey_block_3x allthecompressed:honey_block_4x allthecompressed:honey_block_5x allthecompressed:honey_block_6x allthecompressed:honey_block_7x allthecompressed:honey_block_8x allthecompressed:honey_block_9x allthecompressed:wax_block_1x allthecompressed:wax_block_2x allthecompressed:wax_block_3x allthecompressed:wax_block_4x allthecompressed:wax_block_5x allthecompressed:wax_block_6x allthecompressed:wax_block_7x allthecompressed:wax_block_8x allthecompressed:wax_block_9x
+allthecompressed:honey_block_1x allthecompressed:honey_block_2x allthecompressed:honey_block_3x allthecompressed:honey_block_4x allthecompressed:honey_block_5x allthecompressed:honey_block_6x allthecompressed:honey_block_7x allthecompressed:honey_block_8x allthecompressed:honey_block_9x allthecompressed:wax_block_1x allthecompressed:wax_block_2x allthecompressed:wax_block_3x allthecompressed:wax_block_4x allthecompressed:wax_block_5x allthecompressed:wax_block_6x allthecompressed:wax_block_7x allthecompressed:wax_block_8x allthecompressed:wax_block_9x \
+\
+iceandfire:myrmex_desert_resin_block
 
 # Nether Portal
 block.30020 = nether_portal \
@@ -11026,6 +11124,8 @@ chisel:glassdyedorange \
 createframed:horizontal_orange_stained_framed_glass createframed:orange_stained_framed_glass createframed:orange_stained_tiled_glass createframed:vertical_orange_stained_framed_glass \
 \
 hearth_and_home:orange_stained_barred_glass \
+\
+iceandfire:myrmex_desert_resin_glass \
 \
 immersiveengineering:duroplast \
 \
@@ -11697,6 +11797,8 @@ createframed:green_stained_framed_glass createframed:green_stained_tiled_glass c
 \
 hearth_and_home:green_stained_barred_glass \
 \
+iceandfire:myrmex_jungle_resin_glass \
+\
 mcwwindows:green_mosaic_glass \
 \
 seasonsextras:green_greenhouse_glass \
@@ -11917,6 +12019,8 @@ chisel:array/ice chisel:braid/ice chisel:chaotic_bricks/ice chisel:chaotic_mediu
 chiselsandbits:chiseled_ice \
 \
 ecologics:thin_ice \
+\
+iceandfire:egginice \
 \
 immersive_weathering:frost immersive_weathering:thin_ice \
 \

--- a/item.properties
+++ b/item.properties
@@ -393,6 +393,8 @@ galosphere:glow_ink_clumps \
 \
 gardens_of_the_dead:glowing_soul_spore \
 \
+iceandfire:dread_torch \
+\
 infinitybuttons:soul_torch_button infinitybuttons:soul_torch_lever infinitybuttons:soul_wall_torch_button infinitybuttons:soul_wall_torch_lever \
 \
 mcwlights:soul_acacia_tiki_torch mcwlights:soul_bamboo_tiki_torch mcwlights:soul_birch_tiki_torch mcwlights:soul_cherry_tiki_torch mcwlights:soul_crimson_tiki_torch mcwlights:soul_dark_oak_tiki_torch mcwlights:soul_jungle_tiki_torch mcwlights:soul_mangrove_tiki_torch mcwlights:soul_oak_tiki_torch mcwlights:soul_spruce_tiki_torch mcwlights:soul_warped_tiki_torch \


### PR DESCRIPTION
Every block in Ice and Fire besides the currently broken Dread Portals (they don't render with shaders on).

I have only tested this on Fabric using the [Community Edition](https://modrinth.com/mod/iceandfire-ce) of the mod, but to my knowledge both it and the original Ice and Fire use the same block IDs, so this _should_ hopefully work for both.