### PR TITLE
Add the Diagonal Windows glass panes to layer.translucent

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -15458,7 +15458,9 @@ create:framed_glass_door create:framed_glass_pane create:framed_glass_trapdoor c
 \
 createframed:andesite_alloy_window createframed:andesite_alloy_window_pane createframed:brass_window createframed:brass_window_pane createframed:cardboard_window createframed:cardboard_window_pane createframed:copper_window createframed:copper_window_pane createframed:zinc_window createframed:zinc_window_pane \
 \
-missingwilds:jar
+missingwilds:jar \
+\
+diagonalwindows:blockus/beveled_glass_pane diagonalwindows:createframed/andesite_alloy_window_pane diagonalwindows:createframed/andesite_alloy_window_panew diagonalwindows:createframed/black_cardboard_window_pane diagonalwindows:createframed/cardboard_window_pane diagonalwindows:minecraft/glass_pane
 
 #else
 layer.translucent = glass glass_pane beacon


### PR DESCRIPTION
It just occurred to me that these blocks never got added to the proper layer, preventing the diagonal window variants from looking like the original block.