### PR TITLE
Update Luminax block IDs and correct mod status

### DIFF
--- a/addedMods.md
+++ b/addedMods.md
@@ -260,7 +260,7 @@ Here we can keep track of what mods have been added and what version a contribut
 | [Little Tiles](https://modrinth.com/mod/littletiles) | 1.6.0-pre159 | Fully Added | # Has issues with ACL
 | [Lootr](https://modrinth.com/mod/lootr) | 0.7.35.85 | Fully Added |
 | [Lucky TNT Mod (Too Much TNT)](https://www.curseforge.com/minecraft/mc-mods/luckytnt) | | Unknown | # Wait we don't have an ID for TNT??
-| [Luminax](https://www.curseforge.com/minecraft/mc-mods/luminax) | 1.1.1 | Fully Added |
+| [Luminax](https://www.curseforge.com/minecraft/mc-mods/luminax) | 1.3.0 | Fully Added |
 | [Macaw's Bridges](https://modrinth.com/mod/macaws-bridges) | 3.0.0 | Fully Added |
 | [Macaw's Doors](https://modrinth.com/mod/macaws-doors) | 1.1.3 | Fully Added |
 | [Macaw's Fences and Walls](https://modrinth.com/mod/macaws-fences-and-walls) | 1.2.0 | Fully Added |

--- a/addedMods.md
+++ b/addedMods.md
@@ -260,7 +260,7 @@ Here we can keep track of what mods have been added and what version a contribut
 | [Little Tiles](https://modrinth.com/mod/littletiles) | 1.6.0-pre159 | Fully Added | # Has issues with ACL
 | [Lootr](https://modrinth.com/mod/lootr) | 0.7.35.85 | Fully Added |
 | [Lucky TNT Mod (Too Much TNT)](https://www.curseforge.com/minecraft/mc-mods/luckytnt) | | Unknown | # Wait we don't have an ID for TNT??
-| [Luminax](https://www.curseforge.com/minecraft/mc-mods/luminax) | 1.3.0 | Fully Added |
+| [Luminax](https://www.curseforge.com/minecraft/mc-mods/luminax) | 1.3.0 | Blocks Only |
 | [Macaw's Bridges](https://modrinth.com/mod/macaws-bridges) | 3.0.0 | Fully Added |
 | [Macaw's Doors](https://modrinth.com/mod/macaws-doors) | 1.1.3 | Fully Added |
 | [Macaw's Fences and Walls](https://modrinth.com/mod/macaws-fences-and-walls) | 1.2.0 | Fully Added |

--- a/block.properties
+++ b/block.properties
@@ -7707,7 +7707,7 @@ infinite_abyss:deep_amethyst_crystal infinite_abyss:deep_amethyst_crystal_2 \
 \
 inversia:crying_duct:vertical_direction=down inversia:insomnia_vent inversia:sleep \
 \
-luminax:magenta_block luminax:magenta_button luminax:magenta_pressure_plate luminax:magenta_slab luminax:magenta_stairs luminax:magenta_wall \
+luminax:magenta_luminax_block luminax:magenta_luminax_button luminax:magenta_luminax_pressure_plate luminax:magenta_luminax_slab luminax:magenta_luminax_stairs luminax:magenta_luminax_wall \
 \
 malum:block_of_raw_soulstone malum:block_of_soulstone \
 \
@@ -7977,7 +7977,7 @@ etcetera:iridescent_lantern \
 \
 justagreenhouse:floor_lantern justagreenhouse:greenhouse_lantern \
 \
-luminax:black_block luminax:black_button luminax:black_pressure_plate luminax:black_slab luminax:black_stairs luminax:black_wall luminax:gray_block luminax:gray_button luminax:gray_pressure_plate luminax:gray_slab luminax:gray_stairs luminax:gray_wall luminax:light_gray_block luminax:light_gray_button luminax:light_gray_pressure_plate luminax:light_gray_slab luminax:light_gray_stairs luminax:light_gray_wall luminax:white_block luminax:white_button luminax:white_pressure_plate luminax:white_slab luminax:white_stairs luminax:white_wall \
+luminax:black_luminax_block luminax:black_luminax_button luminax:black_luminax_pressure_plate luminax:black_luminax_slab luminax:black_luminax_stairs luminax:black_luminax_wall luminax:gray_luminax_block luminax:gray_luminax_button luminax:gray_luminax_pressure_plate luminax:gray_luminax_slab luminax:gray_luminax_stairs luminax:gray_luminax_wall luminax:light_gray_luminax_block luminax:light_gray_luminax_button luminax:light_gray_luminax_pressure_plate luminax:light_gray_luminax_slab luminax:light_gray_luminax_stairs luminax:light_gray_luminax_wall luminax:white_luminax_block luminax:white_luminax_button luminax:white_luminax_pressure_plate luminax:white_luminax_slab luminax:white_luminax_stairs luminax:white_luminax_wall \
 \
 rsgauges:industrial_white_blinking_led:power=true rsgauges:industrial_white_led:power=true \
 \
@@ -8103,7 +8103,7 @@ iceandfire:dread_torch iceandfire:dread_torch_wall \
 \
 infinitybuttons:soul_torch_button infinitybuttons:soul_torch_lever infinitybuttons:soul_wall_torch_button infinitybuttons:soul_wall_torch_lever \
 \
-luminax:light_blue_block luminax:light_blue_button luminax:light_blue_pressure_plate luminax:light_blue_slab luminax:light_blue_stairs luminax:light_blue_wall \
+luminax:light_blue_luminax_block luminax:light_blue_luminax_button luminax:light_blue_luminax_pressure_plate luminax:light_blue_luminax_slab luminax:light_blue_luminax_stairs luminax:light_blue_luminax_wall \
 \
 mcwlights:soul_acacia_tiki_torch:lit=true mcwlights:soul_bamboo_tiki_torch:lit=true mcwlights:soul_birch_tiki_torch:lit=true mcwlights:soul_cherry_tiki_torch:lit=true mcwlights:soul_crimson_tiki_torch:lit=true mcwlights:soul_dark_oak_tiki_torch:lit=true mcwlights:soul_jungle_tiki_torch:lit=true mcwlights:soul_mangrove_tiki_torch:lit=true mcwlights:soul_oak_tiki_torch:lit=true mcwlights:soul_spruce_tiki_torch:lit=true mcwlights:soul_warped_tiki_torch:lit=true \
 \
@@ -8249,7 +8249,7 @@ galosphere:glinted_lumiere_cluster galosphere:lumiere_cluster \
 \
 immersiveengineering:electric_lantern:active=true immersiveengineering:floodlight:active=true immersiveengineering:lantern \
 \
-luminax:orange_block luminax:orange_button luminax:orange_pressure_plate luminax:orange_slab luminax:orange_stairs luminax:orange_wall \
+luminax:orange_luminax_block luminax:orange_luminax_button luminax:orange_luminax_pressure_plate luminax:orange_luminax_slab luminax:orange_luminax_stairs luminax:orange_luminax_wall \
 \
 luminousworld:hanging_lantern \
 \
@@ -8349,7 +8349,7 @@ infinitybuttons:soul_lantern_button infinitybuttons:soul_lantern_lever \
 \
 lost_aether_content:boss_doorway_light_gale_stone lost_aether_content:light_gale_stone lost_aether_content:locked_light_gale_stone lost_aether_content:trapped_light_gale_stone lost_aether_content:treasure_doorway_light_gale_stone \
 \
-luminax:cyan_block luminax:cyan_button luminax:cyan_pressure_plate luminax:cyan_slab luminax:cyan_stairs luminax:cyan_wall \
+luminax:cyan_luminax_block luminax:cyan_luminax_button luminax:cyan_luminax_pressure_plate luminax:cyan_luminax_slab luminax:cyan_luminax_stairs luminax:cyan_luminax_wall \
 \
 mcwlights:soul_classic_street_lamp:part=base:lit=true mcwlights:soul_classic_street_lamp:part=top:lit=true mcwlights:soul_double_street_lamp:part=base:lit=true mcwlights:soul_double_street_lamp:part=top:lit=true \
 \
@@ -8442,7 +8442,7 @@ createdeco:red_andesite_lamp:lit=true createdeco:red_brass_lamp:lit=true created
 \
 infinitybuttons:redstone_torch_button:lit=true infinitybuttons:redstone_torch_lever:lit=true infinitybuttons:redstone_wall_torch_button:lit=true infinitybuttons:redstone_wall_torch_lever:lit=true \
 \
-luminax:red_block luminax:red_button luminax:red_pressure_plate luminax:red_slab luminax:red_stairs luminax:red_wall \
+luminax:red_luminax_block luminax:red_luminax_button luminax:red_luminax_pressure_plate luminax:red_luminax_slab luminax:red_luminax_stairs luminax:red_luminax_wall \
 \
 netherexp:ancient_lantern netherexp:ancient_torch netherexp:basaltic_geyser \
 \
@@ -9073,7 +9073,7 @@ galosphere:lumiere_lamp \
 \
 inversia:ochre_selenite \
 \
-luminax:yellow_block luminax:yellow_button luminax:yellow_pressure_plate luminax:yellow_slab luminax:yellow_stairs luminax:yellow_wall \
+luminax:yellow_luminax_block luminax:yellow_luminax_button luminax:yellow_luminax_pressure_plate luminax:yellow_luminax_slab luminax:yellow_luminax_stairs luminax:yellow_luminax_wall \
 \
 luminous_nether:fungirrack_lamp luminous_nether:golden_fungi luminous_nether:golden_mushroom luminous_nether:golden_pop_shroom luminous_nether:large_popshroom \
 \
@@ -9116,7 +9116,7 @@ infinite_abyss:large_glowing_mushroom \
 \
 inversia:verdant_selenite \
 \
-luminax:green_block luminax:green_button luminax:green_pressure_plate luminax:green_slab luminax:green_stairs luminax:green_wall \
+luminax:green_luminax_block luminax:green_luminax_button luminax:green_luminax_pressure_plate luminax:green_luminax_slab luminax:green_luminax_stairs luminax:green_luminax_wall \
 \
 luminous_nether:fungirracklamp_green \
 \
@@ -10852,7 +10852,7 @@ gtceu:brown_borderless_lamp:active=true gtceu:brown_lamp:active=true \
 \
 hearth_and_home:brown_paper_lantern \
 \
-luminax:brown_block luminax:brown_button luminax:brown_pressure_plate luminax:brown_slab luminax:brown_stairs luminax:brown_wall \
+luminax:brown_luminax_block luminax:brown_luminax_button luminax:brown_luminax_pressure_plate luminax:brown_luminax_slab luminax:brown_luminax_stairs luminax:brown_luminax_wall \
 \
 mcwlights:brown_ceiling_light:lit=true mcwlights:brown_lamp:lit=true mcwlights:brown_paper_lamp:lit=true mcwlights:square_wall_lamp:lit=true:dye_color=brown mcwlights:wall_lamp:lit=true:dye_color=brown \
 \
@@ -11054,7 +11054,7 @@ hearth_and_home:lime_paper_lantern \
 \
 iceandfire:pixie_jar_3 \
 \
-luminax:lime_block luminax:lime_button luminax:lime_pressure_plate luminax:lime_slab luminax:lime_stairs luminax:lime_wall \
+luminax:lime_luminax_block luminax:lime_luminax_button luminax:lime_luminax_pressure_plate luminax:lime_luminax_slab luminax:lime_luminax_stairs luminax:lime_luminax_wall \
 \
 mcwlights:lime_ceiling_light:lit=true mcwlights:lime_lamp:lit=true mcwlights:lime_paper_lamp:lit=true mcwlights:square_wall_lamp:lit=true:dye_color=lime mcwlights:wall_lamp:lit=true:dye_color=lime \
 \
@@ -11252,7 +11252,7 @@ gtocore:eternity_coil_block:active=true gtocore:starmetal_coil_block:active=true
 \
 hearth_and_home:blue_paper_lantern \
 \
-luminax:blue_block luminax:blue_button luminax:blue_pressure_plate luminax:blue_slab luminax:blue_stairs luminax:blue_wall \
+luminax:blue_luminax_block luminax:blue_luminax_button luminax:blue_luminax_pressure_plate luminax:blue_luminax_slab luminax:blue_luminax_stairs luminax:blue_luminax_wall \
 \
 mcwlights:blue_ceiling_light:lit=true mcwlights:blue_lamp:lit=true mcwlights:blue_paper_lamp:lit=true mcwlights:square_wall_lamp:lit=true:dye_color=blue mcwlights:wall_lamp:lit=true:dye_color=blue \
 \
@@ -11299,7 +11299,7 @@ hearth_and_home:purple_paper_lantern \
 \
 illagerinvasion:magic_fire \
 \
-luminax:purple_block luminax:purple_button luminax:purple_pressure_plate luminax:purple_slab luminax:purple_stairs luminax:purple_wall \
+luminax:purple_luminax_block luminax:purple_luminax_button luminax:purple_luminax_pressure_plate luminax:purple_luminax_slab luminax:purple_luminax_stairs luminax:purple_luminax_wall \
 \
 luminous_nether:fungirracklamppurple \
 \
@@ -11401,7 +11401,7 @@ hearth_and_home:pink_paper_lantern \
 \
 iceandfire:pixie_jar_0 \
 \
-luminax:pink_block luminax:pink_button luminax:pink_pressure_plate luminax:pink_slab luminax:pink_stairs luminax:pink_wall \
+luminax:pink_luminax_block luminax:pink_luminax_button luminax:pink_luminax_pressure_plate luminax:pink_luminax_slab luminax:pink_luminax_stairs luminax:pink_luminax_wall \
 \
 luminous_nether:fungirracklamp_pink \
 \


### PR DESCRIPTION
Luminax v1.3.0 quietly changed all the block IDs (ex: luminax:white_block -> luminax:white_luminax_block). This updates the block IDs as well as correcting the mod status to be "Blocks Only" because the item IDs don't have properties.