### PR TITLE
Add Bronze mod ore blocks

### DIFF
--- a/addedMods.md
+++ b/addedMods.md
@@ -86,6 +86,7 @@ Here we can keep track of what mods have been added and what version a contribut
 | [The Box Of Horrors](https://modrinth.com/mod/the-box-of-horrors) | | Partial Support |
 | [Brazilian Delight](https://modrinth.com/mod/braziliandelight) | 1.1.0 | Foliage Only |
 | [Brewin' And Chewin'](https://modrinth.com/mod/brewin-and-chewin) | 4.3.0 | Fully Added |
+| [Bronze](https://modrinth.com/mod/bronze) | 2.0.1 | Ores Only |
 | [The Broken Content](https://modrinth.com/mod/thebrokencontent) | 1.5.1 | Blocks Only | #Only added Corrupted bedrock for now as it is the only block that glows.
 | [The Broken Script](https://modrinth.com/mod/the-broken-script) | 1.9.7 | Fully Added | #Only added err.integrity block as mod dev said that should be the only colored block that glows
 | [Burnt](https://modrinth.com/mod/burnt) | | Fully Added |

--- a/block.properties
+++ b/block.properties
@@ -6609,6 +6609,8 @@ block.10368 = nether_quartz_ore \
 \
 alltheores:other_quartz_ore \
 \
+bronze:deepslate_tin_ore_block bronze:tin_ore_block \
+\
 byg:blue_nether_quartz_ore byg:brimstone_nether_quartz_ore \
 \
 cinderscapes:smoky_quartz_ore \


### PR DESCRIPTION
[https://modrinth.com/mod/bronze](https://modrinth.com/mod/bronze)

I've added the Bronze mods only two ore blocks to `block.properties`.

## Before

<img width="1792" height="1008" alt="2025-09-03_20 45 44" src="https://github.com/user-attachments/assets/8a2e5c15-1721-45f3-aa90-0b8b696ce1d2" />

## After

<img width="1792" height="1008" alt="2025-09-03_20 45 41" src="https://github.com/user-attachments/assets/3e7d4ce1-78d7-489f-bda4-35ebb6ffe915" />
