### PR TITLE
Ars Elemental support

### DIFF
--- a/addedMods.md
+++ b/addedMods.md
@@ -48,7 +48,7 @@ Here we can keep track of what mods have been added and what version a contribut
 | [Aquatic Torches](https://modrinth.com/mod/aquatic-torches) | 1.0.1 | Fully Added |
 | [Architect's Palette](https://modrinth.com/mod/architects-palette) | | Partial Support |
 | [Ars Creo](https://www.curseforge.com/minecraft/mc-mods/ars-creo) | 5.1.0 | Fully Added |
-| [Ars Elemental](https://www.curseforge.com/minecraft/mc-mods/ars-elemental) | | Partial Support |
+| [Ars Elemental](https://www.curseforge.com/minecraft/mc-mods/ars-elemental) | 0.7.6.2 | Partial Support | # Added Flashing Archwoods blocks and few flora, still missing few blocks. Set LabPBR > Integrated for better emission on source vines.
 | [Ars Nouveau](https://www.curseforge.com/minecraft/mc-mods/ars-nouveau) | 5.10.2 | Fully Added |
 | [Ars Nouveau's Flavors & Delight](https://modrinth.com/mod/arsdelight) | 2.1.7 | Fully Added |
 | [Ars Énergistique](https://modrinth.com/mod/ars-energistique) | 2.1.1-beta | Fully Added |

--- a/block.properties
+++ b/block.properties
@@ -461,6 +461,8 @@ alexscaves:ancient_sapling alexscaves:bone_worms alexscaves:curly_fern:half=lowe
 \
 ancient_aether:crystal_skyroot_sapling ancient_aether:enchanted_skyroot_sapling ancient_aether:highsproot_sapling ancient_aether:sakura_sapling ancient_aether:sky_grass ancient_aether:skyroot_pine_sapling \
 \
+ars_elemental:yellow_archwood_sapling \
+\
 ars_nouveau:blue_archwood_sapling ars_nouveau:green_archwood_sapling ars_nouveau:magebloom_crop ars_nouveau:purple_archwood_sapling ars_nouveau:red_archwood_sapling ars_nouveau:sourceberry_bush \
 \
 atmospheric:agave atmospheric:aloe_vera atmospheric:arid_sprouts atmospheric:aspen_sapling atmospheric:dry_laurel_sapling atmospheric:firethorn atmospheric:forsythia atmospheric:gilia atmospheric:golden_growths atmospheric:green_aspen_sapling atmospheric:grimwood_sapling atmospheric:hot_monkey_brush atmospheric:kousa_sapling atmospheric:laurel_sapling atmospheric:morado_sapling atmospheric:rosewood_sapling atmospheric:scalding_monkey_brush atmospheric:tall_aloe_vera:half=lower atmospheric:tall_yucca_flower:half=lower atmospheric:warm_monkey_brush atmospheric:water_hyacinth:half=lower atmospheric:yucca_flower atmospheric:yucca_sapling \
@@ -4219,6 +4221,8 @@ block.10204 = mangrove_planks stripped_mangrove_log stripped_mangrove_wood \
 \
 allthecompressed:mangrove_log_1x allthecompressed:mangrove_log_2x allthecompressed:mangrove_log_3x allthecompressed:mangrove_log_4x allthecompressed:mangrove_log_5x allthecompressed:mangrove_log_6x allthecompressed:mangrove_log_7x allthecompressed:mangrove_log_8x allthecompressed:mangrove_log_9x allthecompressed:mangrove_planks_1x allthecompressed:mangrove_planks_2x allthecompressed:mangrove_planks_3x allthecompressed:mangrove_planks_4x allthecompressed:mangrove_planks_5x allthecompressed:mangrove_planks_6x allthecompressed:mangrove_planks_7x allthecompressed:mangrove_planks_8x allthecompressed:mangrove_planks_9x \
 \
+ars_elemental:stripped_yellow_archwood_log ars_elemental:stripped_yellow_archwood
+\
 ars_nouveau:archwood_planks ars_nouveau:stripped_blue_archwood_log ars_nouveau:stripped_blue_archwood_wood ars_nouveau:stripped_green_archwood_log ars_nouveau:stripped_green_archwood_wood ars_nouveau:stripped_purple_archwood_log ars_nouveau:stripped_purple_archwood_wood ars_nouveau:stripped_red_archwood_log ars_nouveau:stripped_red_archwood_wood \
 \
 arsdelight:archwood_cabinet \
@@ -5855,6 +5859,8 @@ block.10313 = light_weighted_pressure_plate:power=0 \
 additionallanterns:gold_chain \
 \
 additionalplacements:blockus.gold_brick_slab additionalplacements:blockus.gold_brick_stairs additionalplacements:blockus.gold_plating_slab additionalplacements:blockus.gold_plating_stairs additionalplacements:enderio.silent_light_weighted_pressure_plate additionalplacements:extshape.gold_slab additionalplacements:extshape.gold_stairs additionalplacements:extshape_blockus.gold_plating_pressure_plate additionalplacements:immersiveengineering.slab_sheetmetal_electrum additionalplacements:immersiveengineering.slab_sheetmetal_gold additionalplacements:immersiveengineering.slab_storage_electrum additionalplacements:minecraft.light_weighted_pressure_plate \
+\
+ars_elemental:source_vines:berries=false ars_elemental:source_vines_plant:berries=false \
 \
 ars_nouveau:agronomic_sourcelink ars_nouveau:alchemical_sourcelink ars_nouveau:brazier_relay:lit=false ars_nouveau:creative_source_jar ars_nouveau:enchanting_apparatus ars_nouveau:gold_grate ars_nouveau:item_detector ars_nouveau:magelight_torch:level=0 ars_nouveau:mob_jar ars_nouveau:mycelial_sourcelink ars_nouveau:potion_diffuser ars_nouveau:potion_jar ars_nouveau:ritual_brazier:lit=false ars_nouveau:sconce ars_nouveau:source_jar ars_nouveau:spell_sensor ars_nouveau:vitalic_sourcelink \
 \
@@ -11041,6 +11047,8 @@ another_furniture:yellow_lamp:lit=true \
 \
 antiblocksrechiseled:bright_yellow antiblocksrechiseled:bright_yellow_border antiblocksrechiseled:button_bright_yellow antiblocksrechiseled:button_wool_yellow antiblocksrechiseled:pressure_plate_bright_yellow antiblocksrechiseled:pressure_plate_wool_yellow antiblocksrechiseled:slab_yellow_bright antiblocksrechiseled:slab_yellow_wool antiblocksrechiseled:stair_yellow_bright antiblocksrechiseled:stair_yellow_wool antiblocksrechiseled:wool_yellow antiblocksrechiseled:wool_yellow_border \
 \
+ars_elemental:sparkflower \
+\
 betterend:iron_bulb_lantern_yellow betterend:terminite_bulb_lantern_yellow betterend:thallasium_bulb_lantern_yellow \
 \
 biomeswevegone:fluorescent_cattail:color=default biomeswevegone:fluorescent_cattail:color=yellow biomeswevegone:yellow_glow_bottle biomeswevegone:yellow_glowcane \
@@ -11364,6 +11372,8 @@ alexscaves:radon_lamp_purple \
 another_furniture:purple_lamp:lit=true \
 \
 antiblocksrechiseled:button_wool_purple antiblocksrechiseled:pressure_plate_wool_purple antiblocksrechiseled:slab_purple_wool antiblocksrechiseled:stair_purple_wool antiblocksrechiseled:wool_purple antiblocksrechiseled:wool_purple_border \
+\
+ars_elemental:source_vines:berries=true ars_elemental:source_vines_plant:berries=true \
 \
 ars_nouveau:brazier_relay:lit=true ars_nouveau:magelight_torch:level=1 ars_nouveau:magelight_torch:level=10 ars_nouveau:magelight_torch:level=11 ars_nouveau:magelight_torch:level=12 ars_nouveau:magelight_torch:level=13 ars_nouveau:magelight_torch:level=14 ars_nouveau:magelight_torch:level=15 ars_nouveau:magelight_torch:level=2 ars_nouveau:magelight_torch:level=3 ars_nouveau:magelight_torch:level=4 ars_nouveau:magelight_torch:level=5 ars_nouveau:magelight_torch:level=6 ars_nouveau:magelight_torch:level=7 ars_nouveau:magelight_torch:level=8 ars_nouveau:magelight_torch:level=9 ars_nouveau:ritual_brazier:lit=true \
 \
@@ -13913,6 +13923,8 @@ block.10297 = oreberries:gold_oreberry_bush
 
 # Glowing Ores Gold
 block.10300 = gold_ore \
+\
+ars_elemental:yellow_archwood_log ars_elemental:yellow_archwood \
 \
 gravelores:gold_gravel_ore \
 \


### PR DESCRIPTION
Added properties to logs of flashing archwood for parity (previously only leaves were in the list) similarly to how other archwoods logs, added light-emitting flora. There would be few more blocks that might or might not benefit from explicit support so i will keep it as partial, i'm not expert enough to tell which id would suit them