### PR TITLE
Update entity.properties to reflect old and new versions

### DIFF
--- a/entity.properties
+++ b/entity.properties
@@ -29,19 +29,23 @@
 # --- IDs should be grouped by mods, for every new mod it should be added in a new line using "\" ---
 #---------------------------------------------------------------------------------------------------------------------
 
-#if MC_VERSION >=  11300
-#1.13 And Above Mapping:
+#1.11 And Above Mapping:
+#if MC_VERSION >= 11100
 
+# End Crystal
 entity.50000 = end_crystal
 
+# Lightning Bolt
 entity.50004 = lightning_bolt \
 \
 ars_nouveau:an_lightning
 
+# Item Frames
 entity.50008 = item_frame glow_item_frame \
 \
 tconstruct:fancy_item_frame
 
+# Iron Golem
 entity.50012 = iron_golem \
 \
 ad_astra:lander ad_astra:tier_1_rocket ad_astra:tier_2_rocket ad_astra:tier_3_rocket ad_astra:tier_4_rocket \
@@ -64,10 +68,13 @@ securitycraft:bouncingbetty securitycraft:bullet securitycraft:security_sea_boat
 \
 yungscavebiomes:ice_cube
 
+# Other Players
 entity.50016 = player mannequin
 
+# Current Player
 entity.50017 = current_player
 
+# Blaze
 entity.50020 = blaze \
 \
 adventurez:blaze_guardian adventurez:blaze_guardian_shield \
@@ -78,24 +85,31 @@ betternether:hydrogen_jellyfish \
 \
 burnt:fire_devil
 
+# Creeper
 entity.50024 = creeper \
 \
 ad_astra:sulfur_creeper \
 \
 enderzoology:concussion_creeper
 
+# Drowned
 entity.50028 = drowned
 
+# Gaurdian
 entity.50032 = guardian
 
+# Elder Guardian
 entity.50036 = elder_guardian
 
+# Endermite
 entity.50040 = endermite
 
+# Ghast
 entity.50044 = ghast \
 \
 enderzoology:dire_wolf enderzoology:wither_witch
 
+# Glow Squid
 entity.50048 = glow_squid \
 \
 betterend:cubozoa \
@@ -104,6 +118,7 @@ betternether:firefly \
 \
 bosses_of_mass_destruction:comet bosses_of_mass_destruction:lich
 
+# Magma Cube
 entity.50052 = magma_cube \
 \
 iceandfire:fire_dragon_charge \
@@ -112,8 +127,10 @@ illagerinvasion:flying_magma \
 \
 wilderwild:scorched
 
+# Stray
 entity.50056 = stray
 
+# Vex
 entity.50060 = vex \
 \
 ad_astra:ice_spit \
@@ -132,14 +149,17 @@ illagerinvasion:skull_bolt \
 \
 tconstruct:crystalshot tconstruct:glow_ball
 
+# Witch
 entity.50064 = witch
 
+# Withers
 entity.50068 = wither wither_skull \
 \
 betternether:naga \
 \
 born_in_chaos_v1:lifestealer born_in_chaos_v1:lifestealer_true_form
 
+# Experience Orbs
 entity.50072 = experience_orb \
 \
 adventurez:void_bullet \
@@ -152,6 +172,7 @@ drg_flares:drg_flare \
 \
 levelz:level_experience_orb
 
+# Boats
 entity.50076 = boat oak_boat spruce_boat birch_boat jungle_boat acacia_boat dark_oak_boat mangrove_boat cherry_boat pale_oak_boat chest_boat oak_chest_boat spruce_chest_boat birch_chest_boat jungle_chest_boat acacia_chest_boat dark_oak_chest_boat mangrove_chest_boat cherry_chest_boat pale_oak_chest_boat \
 \
 ecologics:boat ecologics:chest_boat \
@@ -166,6 +187,7 @@ tfc:wood/boat/acacia tfc:wood/boat/ash tfc:wood/boat/aspen tfc:wood/boat/birch t
 \
 wilderwild:baobab_boat wilderwild:baobab_chest_boat wilderwild:boat wilderwild:chest_boat wilderwild:cypress_boat wilderwild:cypress_chest_boat wilderwild:maple_boat wilderwild:maple_chest_boat wilderwild:palm_boat wilderwild:palm_chest_boat
 
+# Allay
 entity.50080 = allay \
 \
 adventurez:amethyst_golem adventurez:blackstone_golem adventurez:nightmare adventurez:soul_reaper adventurez:the_eye adventurez:tiny_eye \
@@ -186,22 +208,27 @@ supplementaries:bomb \
 \
 tfc:glow_arrow
 
+# Slimes and Chickens
 entity.50084 = slime chicken \
 \
 betterend:end_slime \
 \
 tconstruct:earth_slime tconstruct:ender_slime tconstruct:sky_slime tconstruct:terracube
 
+# Entity Fire
 entity.50088 = entity_flame
 
+# Fire Balls
 entity.50089 = fireball dragon_fireball small_fireball \
 \
 securitycraft:imsbomb
 
+# Trident
 entity.50092 = trident \
 \
 iceandfire:tide_trident
 
+# Minecarts
 entity.50096 = minecart chest_minecart command_block_minecart furnace_minecart hopper_minecart spawner_minecart tnt_minecart \
 \
 fixedminecraft:dispenser_minecart \
@@ -214,8 +241,10 @@ supplementaries:dispenser_minecart \
 \
 tfc:chest_minecart tfc:holding_minecart
 
+# Bogged
 entity.50100 = bogged
 
+# Piglins and Hoglins
 entity.50104 = piglin piglin_brute zombified_piglin hoglin zoglin
 
 entity.50108 = creaking \
@@ -227,23 +256,124 @@ vanillabackport:creaking
 # Name Tag - Iris Exclusive
 entity.50112= name_tag
 
+# Copper Golems
 entity.50116 = copper_golem
 
+# End Crystal Beams
 entity.50200 = end_crystal_beam
 
+# Ender Dragon
 entity.50204 = ender_dragon \
 \
 adventurez:dragon adventurez:ender_whale adventurez:enderwarthog adventurez:void_shadow
 
 #else
-#1.12 And Below Mapping:
+#1.10 And Below Mapping (Cap Sensitive!):
+# End Crystal
+entity.50000 = EnderCrystal 
 
-entity.50060 = eyesinthedarkness:eyes
+# Lightning Bolt
+entity.50004 = lightning_bolt
 
-entity.50072 = xp_orb \
+# Item Frames
+entity.50008 = ItemFrame
+
+# Iron Golem
+entity.50012 = VillagerGolem
+
+# Other Players
+entity.50016 =
+
+# Current Player
+entity.50017 =
+
+# Blaze
+entity.50020 = Blaze \
 \
-lumen:companion_orb lumen:ember lumen:firefly lumen:lightning_bug lumen:psi_firefly lumen:rad_flame lumen:will_o_wisp
+BiomesOPlenty.Pixie
 
-entity.50096 = minecart chest_minecart command_block_minecart furnace_minecart hopper_minecart spawner_minecart tnt_minecart
+# Creeper
+entity.50024 = Creeper
 
+# Drowned
+entity.50028 =
+
+# Gaurdian
+entity.50032 =
+
+# Elder Guardian
+entity.50036 =
+
+# Endermite
+entity.50040 =
+
+# Ghast
+entity.50044 = Ghast
+
+# Glow Squid
+entity.50048 =
+
+# Magma Cube
+entity.50052 = LavaSlime
+
+# Stray
+entity.50056 =
+
+# Vex
+entity.50060 =
+
+# Witch
+entity.50064 = Witch
+
+# Withers
+entity.50068 = WitherBoss WitherSkull
+
+# Experience Orbs
+entity.50072 = XPOrb
+
+# Boats
+entity.50076 = Boat
+
+# Allay
+entity.50080 =
+
+# Slimes and Chickens
+entity.50084 = Slime Chicken \
+\
+BiomesOPlenty.Rosester BiomesOPlenty.Glob
+
+# Entity Fire
+entity.50088 = entity_flame 
+
+# Fire Balls
+entity.50089 = Fireball 
+
+# Trident
+entity.50092 = 
+
+# Minecarts
+entity.50096 = MinecartChest MinecartCommandBlock MinecartFurnace MinecartHopper MinecartRideable MinecartSpawner MinecartTNT
+
+# Bogged
+entity.50100 = 
+
+# Piglins and Hoglins
+entity.50104 = 
+
+# Creaking
+entity.50108 = 
+
+# Name Tag - Iris Exclusive
+entity.50112 =
+
+# Copper Golems
+entity.50116 =
+
+# End Crystal Beams
+entity.50200 = 
+
+# Ender Dragon
+entity.50204 = EnderDragon
 #endif
+
+


### PR DESCRIPTION
"New" versions of Minecraft (1.11+) enforces namespaces while 1.10- kinda lets people do whatever. Though at least from my backport of my mod, I can see that the typical format is modName.entityName.