### PR TITLE
Fix/entries

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -10696,10 +10696,10 @@ block.10873 = trial_spawner:ominous=false:trial_spawner_state=cooldown trial_spa
 # Trial Spawner Ominous Active
 block.10876 = trial_spawner:ominous=true:trial_spawner_state=active trial_spawner:ominous=true:trial_spawner_state=ejecting_reward trial_spawner:ominous=true:trial_spawner_state=waiting_for_players trial_spawner:ominous=true:trial_spawner_state=waiting_for_reward_ejection vault:ominous=true:vault_state=active vault:ominous=true:vault_state=ejecting vault:ominous=true:vault_state=unlocking
 
-# Nether Vines
+# Nether Vines with ACT Light
 block.10884 = weeping_vines_plant
 
-# TODO: what is this used for
+# Nether Vines without ACT Light
 block.10885 = weeping_vines twisting_vines_plant twisting_vines \
 \
 betterend:bulb_vine:shape=middle betterend:bulb_vine:shape=top betterend:charnia_cyan betterend:charnia_green betterend:charnia_light_blue betterend:charnia_orange betterend:charnia_purple betterend:charnia_red betterend:dense_vine:shape=middle betterend:dense_vine:shape=top betterend:end_lily:shape=bottom betterend:end_lily:shape=middle betterend:filalux:shape=middle betterend:filalux:shape=top betterend:jungle_vine betterend:lanceleaf betterend:magnula betterend:murkweed betterend:rubinea betterend:twisted_vine \
@@ -15855,10 +15855,10 @@ block.10873 =
 # Trial Spawner Ominous Active
 block.10876 =
 
-# Nether Vines
+# Nether Vines with ACT Light
 block.10884 =
 
-# TODO: what is this used for
+# Nether Vines without ACT Light
 block.10885 = natura:nether_thorn_vines
 
 # Hay Bale


### PR DESCRIPTION
Fix some inconsistencies spotted between the 1.13+ and 1.12.2 and older properties.
Untested, but unlikely to make things worse.
Additionally I've marked any block ids that seems unused without description as such