### PR TITLE
add missing (lotr) ids to the 1.7.10 section

### DIFF
--- a/block.properties
+++ b/block.properties
@@ -13558,7 +13558,7 @@ spelunkery:light_blue_glowstick
 #    ██║   ██║██╔═══╝    ██╔═══╝ ╚════╝    ██╔══██║██╔══╝  ██╔══██╗██╔══╝
 #    ██║██╗██║███████╗██╗███████╗          ██║  ██║███████╗██║  ██║███████╗
 #    ╚═╝╚═╝╚═╝╚══════╝╚═╝╚══════╝          ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝
-# This is for Minecraft 1.12.2 and earlier
+# This is for Minecraft 1.12.2 and earlier (except 1.7.10, which has its own section below)
 
 #if MC_VERSION >= 10800 && MC_VERSION <= 11202
 
@@ -16648,8 +16648,12 @@ block.32016 = beacon
 #  ██║   ██╔╝  ██║████╔╝██║    ██╔══██║██╔══╝  ██╔══██╗██╔══╝
 #  ██║██╗██║██╗██║╚██████╔╝    ██║  ██║███████╗██║  ██║███████╗
 #  ╚═╝╚═╝╚═╝╚═╝╚═╝ ╚═════╝     ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝
-#
+# This is for minecraft 1.7.10
 #if MC_VERSION == 10710
+
+######### BLOCKS ENTITIES #########
+
+block.5000=
 
 # Signs
 block.5004 = standing_sign wall_sign \
@@ -16669,8 +16673,27 @@ block.5016 = skull bed \
 \
 lotr:tile.dwarvenBed lotr:tile.elvenBed lotr:tile.highElvenBed lotr:tile.lionBed lotr:tile.orcBed lotr:tile.strawBed lotr:tile.wargFurBed lotr:tile.woodElvenBed
 
+# Conduits
+block.5020 =
+
 # End Portal
 block.5024 = end_portal
+
+# Bell
+block.5028 =
+
+block.5032=
+
+block.5036=
+
+
+######### BLOCKS #########
+
+##### FOLIAGE #####
+
+
+# No Directional Shading
+block.10001 =
 
 # Small Flowers / Flowers Lower Half - Euphoria Patches Emissive Flowers
 block.10003 = yellow_flower red_flower \
@@ -16683,43 +16706,79 @@ block.10005 = double_plant:0,1,2,3,4,5 tallgrass sapling deadbush wheat carrots 
 lotr:tile.aridGrass lotr:tile.athelas lotr:tile.blackroot lotr:tile.clover lotr:tile.cornStalk lotr:tile.corruptMallorn lotr:tile.deadMarshPlant lotr:tile.doubleFlower:1 lotr:tile.fruitSapling lotr:tile.grapevineRed lotr:tile.grapevineWhite lotr:tile.leek lotr:tile.lettuce lotr:tile.mordorGrass lotr:tile.mordorThorn lotr:tile.morgulShroom lotr:tile.pipeweed lotr:tile.sapling lotr:tile.sapling2 lotr:tile.sapling3 lotr:tile.sapling4 lotr:tile.sapling5 lotr:tile.sapling6 lotr:tile.sapling7 lotr:tile.sapling8 lotr:tile.sapling9 lotr:tile.tallGrass:0,1,2,4,5 lotr:tile.turnip lotr:tile.yam
 
 # Leaves - Not affected by Euphoria Patches Seasons (Don't tint in Autumn, get snow in winter)
-block.10007 = leaves:1,5,9,13,3,7,11,15 leaves2:0,4,8,12,2,3,6,7,10,11,14,15 \
+block.10007 = leaves:1,3,5,7,9,11,13,15 leaves2:0,4,8,12 \
 \
 lotr:tile.fruitLeaves lotr:tile.leaves lotr:tile.leaves2 lotr:tile.leaves3 lotr:tile.leaves4 lotr:tile.leaves5 lotr:tile.leaves6 lotr:tile.leaves7 lotr:tile.leaves8 lotr:tile.leaves9
 
 # Leaves
-block.10009 = leaves:0,4,8,12,2,6,10,14 leaves2:1,5,9,13 \
+block.10009 = leaves:0,2,4,6,8,10,12,14 leaves2:1,5,9,13 \
 \
 lotr:tile.berryBush
+
+# Leaves - Euphoria Patches Emissive Flowers
+block.10011 =
 
 # Waving Foliage - Vine
 block.10013 = vine \
 \
 lotr:tile.mirkVines lotr:tile.willowVines
 
+# Non-Waving Foliage - Euphoria Patches Interactive Foliage
+block.10015 = lotr:tile.fallenLeaves lotr:tile.fallenLeavesLOTR lotr:tile.fallenLeavesLOTR2 lotr:tile.fallenLeavesLOTR3 lotr:tile.driedReeds lotr:tile.reeds lotr:tile.mordorMoss
+
 # Non-Waving Foliage
 block.10017 = web \
 \
 lotr:tile.webUngoliant
 
+# Non-Waving Flowers - Euphoria Patches Emissive Flowers
+block.10019 =
+
 # Tall Foliage Upper Half
 block.10021 = double_plant:8,9,10,11
+
+# Tall Flowers Upper half - Euphoria Patches Emissive Flowers
+block.10023 = lotr:tile.doubleFlower:8,9,10,11
+
+# Automatic glowing modded ores - Stone
+block.10024 = lotr:tile.oreMithril lotr:tile.oreMorgulIron lotr:tile.oreSalt lotr:tile.oreSaltpeter lotr:tile.oreSilver lotr:tile.oreSulfur lotr:tile.oreTin
+
+# Short Foliage / Foliage Lower Half - No Subsurface Scattering
+block.10025 =
+
+# Automatic glowing modded ores - Netherrack
+block.10026 =
+
+# Tall Foliage / Foliage Upper Half - No Subsurface Scattering
+block.10027 =
+
+# Automatic glowing modded ores - Endstone
+block.10028 =
+
+# Crimson Roots - Better Color balance for Soul Sand Valley Overhaul
+block.10029 =
+
+# Short Foliage - No Euphoria Patches Interactive Foliage
+block.10031 =
 
 # Stone Bricks
 block.10032 = stonebrick monster_egg:2,3,4,5 double_stone_slab:5,13 \
 \
 lotr:tile.blueDwarvenCraftingTable lotr:tile.brick2:2,3,4,5,6,13,14,15 lotr:tile.brick3:0,1,2,3,4,5,6,7 lotr:tile.brick4:0,1,2,8,9,10,11,12,13 lotr:tile.brick5:1,3,11,12,13,14,15 lotr:tile.brick6:0,1,2,3,4,5,6,7,8 lotr:tile.brick:4,11,12,13,14 lotr:tile.pillar2:2,5,8,9,13,14 lotr:tile.pillar:1,2,3,4,8,10,11,12,13,14 lotr:tile.rhunCraftingTable lotr:tile.slabDouble10:0 lotr:tile.slabDouble12:0,1,2,3,4,5,6 lotr:tile.slabDouble13:0,1,7 lotr:tile.slabDouble14:0 lotr:tile.slabDouble2:1,3,4,5,6,7 lotr:tile.slabDouble3:0,1,2,5,6,7 lotr:tile.slabDouble4:1,2,3 lotr:tile.slabDouble5:2,5,6,7 lotr:tile.slabDouble6:0,1,2,3,4,5,6 lotr:tile.slabDouble8:0,1,2,5 lotr:tile.slabDouble9:2,6 lotr:tile.slabDouble:6 lotr:tile.slabDoubleV:0,1 lotr:tile.smoothStone:2,3,4 lotr:tile.tauredainDartTrap
 
+# Stone Brick Walls
+block.10033 = lotr:tile.wallStoneV:1,2,3 lotr:tile.wallStone:6,10,11,12,14 lotr:tile.wallStone2:3,4,5,6,11,12,13  lotr:tile.wallStone3:0,1,2,9,15 lotr:tile.wallStone4:0,1,2,10,11,12,13,14,15
+
 # Stone Brick Slabs and Stairs
 block.10035 = stone_slab:5,13 stone_brick_stairs \
 \
 lotr:tile.slabSingle10:0,8 lotr:tile.slabSingle12:0,1,2,3,4,5,6,8,9,10,11,12,13,14 lotr:tile.slabSingle13:0,1,7,8,9,15 lotr:tile.slabSingle14:0,8 lotr:tile.slabSingle2:1,3,4,5,6,7,9,11,12,13,14,15 lotr:tile.slabSingle3:0,1,2,5,6,7,8,9,10,13,14,15 lotr:tile.slabSingle4:1,2,3,9,10,11 lotr:tile.slabSingle5:2,5,6,7,10,13,14,15 lotr:tile.slabSingle6:0,1,2,3,4,5,6,8,9,10,11,12,13,14 lotr:tile.slabSingle8:0,1,2,5,8,9,10,13 lotr:tile.slabSingle9:2,6,10,14 lotr:tile.slabSingle:6,14 lotr:tile.slabSingleV:0,1,8,9 lotr:tile.stairsArnorBrick lotr:tile.stairsArnorBrickCracked lotr:tile.stairsArnorBrickMossy lotr:tile.stairsBlueRockBrick lotr:tile.stairsDaleBrick lotr:tile.stairsDaleBrickCracked lotr:tile.stairsDaleBrickMossy lotr:tile.stairsElvenBrick lotr:tile.stairsElvenBrickCracked lotr:tile.stairsElvenBrickMossy lotr:tile.stairsHighElvenBrick lotr:tile.stairsHighElvenBrickCracked lotr:tile.stairsHighElvenBrickMossy lotr:tile.stairsRedRockBrick lotr:tile.stairsRhunBrick lotr:tile.stairsRhunBrickCracked lotr:tile.stairsRhunBrickFlowers lotr:tile.stairsRhunBrickMossy lotr:tile.stairsRhunBrickRed lotr:tile.stairsRohanBrick lotr:tile.stairsStoneBrickCracked lotr:tile.stairsStoneBrickMossy lotr:tile.stairsTauredainBrick lotr:tile.stairsTauredainBrickCracked lotr:tile.stairsTauredainBrickMossy lotr:tile.stairsWoodElvenBrick lotr:tile.stairsWoodElvenBrickCracked lotr:tile.stairsWoodElvenBrickMossy
 
-# Anvil
-block.10037 = anvil
-
 # Sugar Cane
 block.10039 = reeds
+
+# Anvil
+block.10037 = anvil
 
 # Rails
 block.10041 = golden_rail detector_rail rail activator_rail \
@@ -16737,8 +16796,17 @@ block.10047 = hopper:8,10,11,12,13
 # Cauldron With Water
 block.10049 = cauldron:1,2,3
 
+# Powder Snow Cauldron
+block.10053 =
+
+# Lava Cauldron
+block.10056 = lotr:tile.unsmeltery:10,11,12,13
+
 # Lever
 block.10061 = lever
+
+# Lectern
+block.10065 =
 
 # Still Lava - Euphoria Patches Lava Noise
 block.10068 = lava
@@ -16751,13 +16819,18 @@ block.10072 = fire \
 \
 lotr:tile.rhunFire
 
+# Soul Fire
+block.10076 =
+
+##### STONE #####
+
 # Enabled Redstone Stone Blocks - Euphoria Patches Redstone IPBR
 block.10079 = stone_pressure_plate:1 stone_button:8,9,10,11,12,13,14,15 \
 \
 lotr:tile.buttonBlueRock:9,10,11,12 lotr:tile.buttonRedRock:9,10,11,12 lotr:tile.buttonRohanRock:9,10,11,12 lotr:tile.pressurePlateBlueRock:1 lotr:tile.pressurePlateRedRock:1 lotr:tile.pressurePlateRohanRock:1
 
 # Stone Full Blocks
-block.10080 = stone monster_egg:0 coal_ore double_stone_slab:0,8 \
+block.10080 = stone:0 monster_egg:0 coal_ore double_stone_slab:0,8 \
 \
 lotr:tile.dwarvenDoor lotr:tile.dwarvenDoorIthildin lotr:tile.goran lotr:tile.oreQuendite lotr:tile.rock:2,3,4 lotr:tile.slabDouble11:4,5,6 lotr:tile.slabDoubleV:5 lotr:tile.smoothStoneV
 
@@ -16774,33 +16847,95 @@ lotr:tile.slabSingle11:4,5,6,12,13,14 lotr:tile.slabSingleV:5,13 lotr:tile.stair
 # Granite Full Block
 block.10084 =
 
+# Granite Non-Full Blocks
+block.10085 =
+
+# Granite Slabs and Stairs
+block.10087 =
+
 # Diorite Full Block
 block.10088 = lotr:tile.rock:1 lotr:tile.slabDouble11:3
+
+# Diorite Non-Full Blocks
+block.10089 = lotr:tile.wallStone:2 lotr:tile.pressurePlateGondorRock lotr:tile.buttonGondorRock
+
+# Diorite Slabs and Stairs
+block.10091 = lotr:tile.stairsGondorRock lotr:tile.slabSingle11:3,11
 
 # Andesite Full Block
 block.10092 =
 
+# Andesite Non-Full Blocks
+block.10093 =
+
+# Andesite Slabs and Stairs
+block.10095 =
+
 # Polished Granite Full Block
 block.10096 =
 
+# Polished Granite Non-Full Blocks
+block.10099 =
+
 # Polished Diorite Full Block
 block.10100 = lotr:tile.brick3:9 lotr:tile.brick5:8,9,10 lotr:tile.brick:1,2,3,5 lotr:tile.dolAmrothCraftingTable lotr:tile.gondorianCraftingTable lotr:tile.guldurilBrick:6,7,8 lotr:tile.pillar:6 lotr:tile.slabDouble11:0,1,2 lotr:tile.slabDouble5:0 lotr:tile.slabDouble6:7 lotr:tile.slabDouble:2,3,4,5 lotr:tile.smoothStone:1
+
+# Polished Diorite Non-Full Blocks
+block.10103 = lotr:tile.stairsGondorBrick lotr:tile.stairsGondorBrickCracked lotr:tile.stairsGondorBrickMossy lotr:tile.stairsGondorBrickRustic lotr:tile.stairsGondorBrickRusticCracked lotr:tile.stairsGondorBrickRusticMossy lotr:tile.stairsDolAmrothBrick lotr:tile.wallStone:3,4,5 lotr:tile.wallStone2:14 lotr:tile.wallStone4:7,8,9 lotr:tile.slabSingle:2,3,4,5,10,11,12,13 lotr:tile.slabSingle5:0,8 lotr:tile.slabSingle6:7,15 lotr:tile.slabSingle11:0,1,2,8,9,10
 
 # Polished Andesite Full Block / Mud Brick Full Block / Bricks
 block.10104 = brick_block double_stone_slab:4,12 \
 \
 lotr:tile.brick5:0 lotr:tile.hearth lotr:tile.pillar2:3 lotr:tile.redBrick lotr:tile.slabDouble9:3,5 lotr:tile.slabDoubleV:2,3
 
+# Brick Walls
+block.10105 = lotr:tile.wallStoneV:6,7,8 lotr:tile.wallStone3:8
+
 # Polished Andesite / Mud Brick Slabs and Stairs
 block.10107 = brick_stairs stone_slab:4,12 \
 \
 lotr:tile.slabSingle9:3,5,11,13 lotr:tile.slabSingleV:2,3,10,11 lotr:tile.stairsBrickCracked lotr:tile.stairsBrickMossy lotr:tile.stairsMudBrick
 
+# Deepslate - Full Blocks
+block.10108 = lotr:tile.utumnoBrick:2,3,6 lotr:tile.utumnoBrickEntrance lotr:tile.utumnoPillar:1
+
+# Deepslate - Walls
+block.10109 =
+
+# Cobbled Deepslate stairs and slabs
+block.10111 =
+
+# Other Deepslate - Full Blocks / Mangrove Full Blocks
+block.10112 = lotr:tile.brick2:12 lotr:tile.brick4:5 lotr:tile.brick:6,8,9,10 lotr:tile.dwarvenCraftingTable lotr:tile.pillar2:0 lotr:tile.pillar:0 lotr:tile.quagmire lotr:tile.slabDouble2:0 lotr:tile.slabDouble7:6,7 lotr:tile.slabDouble:7 lotr:tile.slabUtumnoDouble2:0 lotr:tile.slabUtumnoDouble:1,4
+
+# Other Deepslate - Non-Full Blocks / Mangrove Non-Full Blocks
+block.10113 = lotr:tile.wallStone:7 lotr:tile.wallStone4:5 lotr:tile.wallUtumno:1,3
+
+# Deepslate Slabs and Stairs
+block.10115 = lotr:tile.stairsDwarvenBrick lotr:tile.stairsDwarvenBrickCracked lotr:tile.slabSingle:7,15 lotr:tile.slabSingle2:0,8 lotr:tile.slabSingle7:6,7,14,15 lotr:tile.slabUtumnoSingle:1,4,9,12 lotr:tile.slabUtumnoSingle2:0,8 lotr:tile.stairsUtumnoBrickIce lotr:tile.stairsUtumnoTileIce
+
+# Calcite Blocks
+block.10116 =
+
+# Calcite Non-Full Blocks (Modded Only)
+block.10117 =
+
+# Dripstone
+block.10120 =
+
+# Pointed Dripstone
+block.10121 =
+
 # Daylight Detector
 block.10123 = daylight_detector daylight_detector_inverted
 
+##### DIRT #####
+
 # Snowy Dirt Blocks
 block.10124 =
+
+# Snowy Dirt Block Non-Full Blocks
+block.10125 =
 
 # Normal Mycelium
 block.10126 = mycelium
@@ -16810,8 +16945,8 @@ block.10128 = dirt \
 \
 lotr:tile.mordorDirt lotr:tile.mud lotr:tile.remains lotr:tile.slabDoubleDirt:0,2,3 lotr:tile.slabSingleDirt:0,2,3,8,10,11 lotr:tile.termiteMound
 
-# Farmland (Dry)
-block.10129 = farmland:0 \
+# Farmland Moisture 0-6
+block.10129 = farmland:0,1,2,3,4,5,6 \
 \
 lotr:tile.mudFarmland:0,1,2,3,4,5,6
 
@@ -16820,13 +16955,34 @@ block.10132 = grass \
 \
 lotr:tile.mudGrass lotr:tile.quenditeGrass
 
-# Farmland (Moist)
-block.10137 = farmland:1,2,3,4,5,6 \
+# Grass Non-Full Block (Modded Only)
+block.10133 =
+
+# Farmland Moisture 7 (Fully Moist)
+block.10137 = farmland:7 \
 \
 lotr:tile.mudFarmland:7
 
 # Netherrack
 block.10140 = netherrack
+
+# Netherrack Non-Full Blocks (Modded Only)
+block.10141 =
+
+# Warped Nylium
+block.10144 =
+
+# Warped Wart Block - Euphoria Patched Emissive Wart Blocks
+block.10146 =
+
+# Warped Wart Non-Full Block (Modded Only)
+block.10147 =
+
+# Crimson Nylium
+block.10148 =
+
+# Crimson Nylium Non-Full Block / Nether Wart Non-Full Block
+block.10149 =
 
 # Nether Wart Block - Euphoria Patched Emissive Wart Blocks
 block.10150 =
@@ -16851,6 +17007,9 @@ block.10155 = stone_slab:3 stone_slab:11 stone_stairs \
 \
 lotr:tile.scorchedSlabSingle lotr:tile.slabSingleV:4,12 lotr:tile.stairsCobblestoneMossy lotr:tile.stairsScorchedStone
 
+##### WOOD #####
+
+
 # Oak Full Blocks
 block.10156 = planks:0,6,7,8,9,10,11,12,13,14,15 double_wooden_slab:0,6,7,8,14,15 bookshelf crafting_table double_stone_slab:2,10 \
 \
@@ -16870,6 +17029,9 @@ lotr:tile.stairsAspen lotr:tile.stairsBaobab lotr:tile.stairsBeech lotr:tile.sta
 block.10160 = log:0,4,8,12 \
 \
 lotr:tile.wood2:1,5,9,13 lotr:tile.wood4:1,5,9,13 lotr:tile.wood5:0,1,4,5,8,9,12,13 lotr:tile.wood7:0,4,8,12 lotr:tile.wood:0,4,8,12 lotr:tile.woodBeam1:0,4,8,12 lotr:tile.woodBeam2:1,5,9,13 lotr:tile.woodBeam4:1,5,9,13 lotr:tile.woodBeam5:0,1,4,5,8,9,12,13 lotr:tile.woodBeam7:0,4,8,12 lotr:tile.woodBeamV1:0,4,8,12
+
+# Oak Non-Full Logs (Modded Only)
+block.10161 =
 
 # Spruce Full Blocks
 block.10164 = planks:1 double_wooden_slab:1,9 \
@@ -16891,6 +17053,9 @@ block.10168 = log:1,5,9,13 \
 \
 lotr:tile.rottenLog lotr:tile.wood4:0,2,4,6,8,10,12,14 lotr:tile.wood5:2,6,10,14 lotr:tile.wood6:3,7,11,15 lotr:tile.woodBeam4:0,2,4,6,8,10,12,14 lotr:tile.woodBeam5:2,6,10,14 lotr:tile.woodBeam6:3,7,11,15 lotr:tile.woodBeamRotten lotr:tile.woodBeamS lotr:tile.woodBeamV1:1,5,9,13
 
+# Spruce Non-Full Logs (Modded Only)
+block.10169 =
+
 # Birch Full Blocks
 block.10172 = planks:2 double_wooden_slab:2,10 \
 \
@@ -16910,6 +17075,9 @@ lotr:tile.stairsAlmond lotr:tile.stairsApple lotr:tile.stairsCypress lotr:tile.s
 block.10176 = log:2,6,10,14 \
 \
 lotr:tile.fruitWood:0,4,8,12 lotr:tile.wood2:2,6,10,14 lotr:tile.wood3:0,4,8,12 lotr:tile.wood6:2,6,10,14 lotr:tile.wood7:2,3,6,7,10,11,14,15 lotr:tile.wood8:2,6,10,14 lotr:tile.wood:1,5,9,13 lotr:tile.woodBeam1:1,5,9,13 lotr:tile.woodBeam2:2,6,10,14 lotr:tile.woodBeam3:0,4,8,12 lotr:tile.woodBeam6:2,6,10,14 lotr:tile.woodBeam7:2,3,6,7,10,11,14,15 lotr:tile.woodBeam8:2,6,10,14 lotr:tile.woodBeamFruit:0,4,8,12 lotr:tile.woodBeamV1:2,6,10,14
+
+# Birch Non-Full Logs (Modded Only)
+block.10177 =
 
 # Jungle Full Blocks
 block.10180 = planks:3 double_wooden_slab:3,11 \
@@ -16931,6 +17099,9 @@ block.10184 = log:3,7,11,15 \
 \
 lotr:tile.fruitWood:3,7,11,15 lotr:tile.wood4:3,7,11,15 lotr:tile.wood6:1,5,9,13 lotr:tile.wood8:3,7,11,15 lotr:tile.wood9:0,1,4,5,8,9,12,13 lotr:tile.woodBeam4:3,7,11,15 lotr:tile.woodBeam6:1,5,9,13 lotr:tile.woodBeam8:3,7,11,15 lotr:tile.woodBeam9:0,1,4,5,8,9,12,13 lotr:tile.woodBeamFruit:3,7,11,15 lotr:tile.woodBeamV1:3,7,11,15
 
+# Jungle Non-Full Logs (Modded Only)
+block.10185 =
+
 # Acacia Full Blocks
 block.10188 = planks:4 double_wooden_slab:4,12 \
 \
@@ -16950,6 +17121,9 @@ lotr:tile.stairsBanana lotr:tile.stairsDatePalm lotr:tile.stairsLime lotr:tile.s
 block.10192 = log2:0,4,8,12,2,6,10,14 \
 \
 lotr:tile.fruitWood:1,5,9,13 lotr:tile.wood2:3,7,11,15 lotr:tile.wood3:2,6,10,14 lotr:tile.wood5:3,7,11,15 lotr:tile.wood8:1,5,9,13 lotr:tile.woodBeam2:3,7,11,15 lotr:tile.woodBeam3:2,6,10,14 lotr:tile.woodBeam5:3,7,11,15 lotr:tile.woodBeam8:1,5,9,13 lotr:tile.woodBeamFruit:1,5,9,13 lotr:tile.woodBeamV2:0,4,8,12
+
+# Acacia Non-Full Logs (Modded Only)
+block.10193 =
 
 # Dark Oak Full Blocks
 block.10196 = planks:5 double_wooden_slab:5,13 \
@@ -16971,23 +17145,87 @@ block.10200 = log2:1,5,9,13,3,7,11,15 \
 \
 lotr:tile.wood2:0,4,8,12 lotr:tile.wood3:1,3,5,7,9,11,13,15 lotr:tile.wood6:0,4,8,12 lotr:tile.wood7:1,5,9,13 lotr:tile.wood8:0,4,8,12 lotr:tile.wood:2,3,6,7,10,11,14,15 lotr:tile.woodBeam1:2,3,6,7,10,11,14,15 lotr:tile.woodBeam2:0,4,8,12 lotr:tile.woodBeam3:1,3,5,7,9,11,13,15 lotr:tile.woodBeam6:0,4,8,12 lotr:tile.woodBeam7:1,5,9,13 lotr:tile.woodBeam8:0,4,8,12 lotr:tile.woodBeamV2:1,5,9,13
 
+# Dark Oak Non-Full Logs (Modded Only)
+block.10201 =
+
+# Mangrove Full Blocks
+block.10204 =
+
+# Mangrove Non-Full Blocks
+block.10205 =
+
+# Mangrove Powered Blocks - Euphoria Patches Redstone IPBR
+block.10207 =
+
+# Mangrove Logs
+block.10208 =
+
+# Mangrove Non-Full Logs (Modded Only)
+block.10209 =
+
+# Crimson Wood Full Blocks
+block.10212 =
+
+# Crimson Wood Non-Full Blocks
+block.10213 =
+
+# Crimson Wood Powered Blocks - Euphoria Patches Redstone IPBR
+block.10215 =
+
+# Crimson Stem
+block.10216 =
+
+# Crimson Non-Full Stems (Modded Only)
+block.10217 =
+
+# Warped Wood Full Blocks
+block.10220 =
+
+# Warped Wood Non-Full Blocks
+block.10221 =
+
+# Warped Wood Powered Blocks - Euphoria Patches Redstone IPBR
+block.10223 =
+
+# Warped Stem
+block.10224 =
+
+# Warped Non-Full Stem (Modded Only)
+block.10225 =
+
 # Bedrock
 block.10228 = bedrock
+
+# Bedrock Non-Full Blocks (Modded Only)
+block.10229 =
+
+
+##### SAND #####
+
 
 # Sand
 block.10232 = sand:0,2,3,4,5,6,7,8,9,10,11,12,13,14,15 \
 \
 lotr:tile.slabDoubleSand:0,2 lotr:tile.whiteSand
 
+# Sand Non-Full Blocks (Modded Only)
+block.10233 = lotr:tile.slabSingleSand:0,2,8,10
+
 # Red Sand
 block.10236 = sand:1 \
 \
 lotr:tile.slabDoubleSand:1
 
+# Red Sand Non-Full Blocks (Modded Only)
+block.10237 = lotr:tile.slabSingleSand:1,9
+
 # Sandstone Full Block
 block.10240 = sandstone double_stone_slab:1,9 \
 \
 lotr:tile.brick3:8,11 lotr:tile.brick4:7 lotr:tile.brick:15 lotr:tile.gulfCraftingTable lotr:tile.nearHaradCraftingTable lotr:tile.pillar2:10 lotr:tile.pillar:5,15 lotr:tile.slabDouble10:6 lotr:tile.slabDouble13:2,3,4 lotr:tile.slabDouble4:0,7 lotr:tile.slabDouble7:1 lotr:tile.umbarCraftingTable lotr:tile.whiteSandstone
+
+# Sandstone Non-Full Block
+block.10241 = lotr:tile.kebabStandSand lotr:tile.wallStone3:3,14 lotr:tile.wallStone5:0,1 lotr:tile.wallStone:15 lotr:tile.wallStoneV:4
 
 # Sandstone Slabs and Stairs
 block.10243 = stone_slab:1,9 sandstone_stairs \
@@ -16997,55 +17235,176 @@ lotr:tile.slabSingle10:6,14 lotr:tile.slabSingle13:2,3,4,10,11,12 lotr:tile.slab
 # Red Sandstone Full Block
 block.10244 = lotr:tile.brick3:13,14,15 lotr:tile.pillar2:15 lotr:tile.redSandstone lotr:tile.slabDouble7:2,3,4,5
 
+# Red Sandstone Walls
+block.10245 = lotr:tile.wallStone3:4,5 lotr:tile.wallStoneV:5
+
 # Red Sandstone Slabs and Stairs
 block.10247 = lotr:tile.slabSingle7:2,3,4,5,10,11,12,13 lotr:tile.stairsNearHaradBrickRed lotr:tile.stairsNearHaradBrickRedCracked lotr:tile.stairsRedSandstone
+
+# Netherite Blocks
+block.10248 = lotr:tile.oreStorage:5,9 lotr:tile.oreStorage2:0
+
+# Netherite Non-Full Blocks (Modded Only)
+block.10249 = lotr:tile.gateOrc lotr:tile.gateUruk lotr:tile.orcBomb lotr:tile.orcSteelBars lotr:tile.urukBars lotr:tile.utumnoReturnPortalBase
+
+# Ancient Debris
+block.10252 = lotr:tile.orcPlating
+
+# Ancient Debris Non-Full Blocks (Modded Only)
+block.10253 =
 
 # Iron Bars
 block.10257 = iron_bars \
 \
 lotr:tile.blueDwarfBars lotr:tile.bronzeBars lotr:tile.dwarfBars lotr:tile.galadhrimBars lotr:tile.highElfBars lotr:tile.woodElfBars
 
+# Declared but unused in Complementary itself
+block.10260 =
+
 # Iron Blocks
 block.10264 = iron_block \
 \
 lotr:tile.aleHorn lotr:tile.birdCage:0,1 lotr:tile.gateBronzeBars lotr:tile.gateDolAmroth lotr:tile.gateDwarven lotr:tile.gateElven lotr:tile.gateGondor lotr:tile.gateHighElven lotr:tile.gateIronBars lotr:tile.gateRhun lotr:tile.gateRohan lotr:tile.oreStorage2:1,2 lotr:tile.oreStorage:1,2,7,8,12,15 lotr:tile.rhunFireJar
 
+# Unpowered Heavy Weighted Pressure Plate - Euphoria Patches Redstone IPBR
+block.10265 = heavy_weighted_pressure_plate:0
+
+# Powered Heavy Weighted Pressure Plate - Euphoria Patches Redstone IPBR
+block.10267 = heavy_weighted_pressure_plate:1 heavy_weighted_pressure_plate:2 heavy_weighted_pressure_plate:3 heavy_weighted_pressure_plate:4 heavy_weighted_pressure_plate:5 heavy_weighted_pressure_plate:6 heavy_weighted_pressure_plate:7 heavy_weighted_pressure_plate:8 heavy_weighted_pressure_plate:9 heavy_weighted_pressure_plate:10 heavy_weighted_pressure_plate:11 heavy_weighted_pressure_plate:12 heavy_weighted_pressure_plate:13 heavy_weighted_pressure_plate:14 heavy_weighted_pressure_plate:15
+
+# Euphoria Patches Glowing Raw Iron Blocks
+block.10268 =
+
+# Glowing Raw Iron Non-Full Blocks (Modded Only)
+block.10269 =
+
 # Glowing Ores Iron
 block.10272 = iron_ore
 
+# Deepslate Variant
+block.10276 =
+
+# Euphoria Patches Glowing Raw Copper Blocks
+block.10280 =
+
+# Glowing Raw Copper Blocks Non-Full Blocks (Modded Block)
+block.10281 =
+
+# Glowing Ores Copper
+block.10284 = lotr:tile.oreCopper
+
+# Deepslate Variant
+block.10288 =
+
+# Copper Full Blocks
+block.10292 = lotr:tile.oreStorage:0
+
+# Copper Non-Full Blocks
+block.10293 = lotr:tile.treasureCopper lotr:tile.gobletCopper
+
+# Copper Slabs and Stairs
+block.10295 =
+
+# Euphoria Patches Glowing Raw Gold Blocks
+block.10296 =
+
+# Glowing Raw Gold Blocks Non-Full Blocks (Modded Block)
+block.10297 =
+
 # Glowing Ores Gold
 block.10300 = gold_ore
+
+# Glowing Ores Gold Non-Full Block (Modded Only)
+block.10301 =
+
+# Deepslate Gold Ore Variant
+block.10302 =
+
+# Pink Modded Ores
+block.10304 =
+
+# Purple Modded Ores
+block.10306 =
+
+# Glowing Ores Nether Gold
+block.10308 =
 
 # Gold Blocks
 block.10312 = gold_block \
 \
 lotr:tile.aleHornGold lotr:tile.birdCage:2,3 lotr:tile.brick4:3 lotr:tile.gateGold lotr:tile.gateMithril lotr:tile.gateNearHarad lotr:tile.gateSilver lotr:tile.gobletGold lotr:tile.gobletSilver lotr:tile.goldBars lotr:tile.mithrilBars lotr:tile.oreStorage:3,4 lotr:tile.pillar2:11 lotr:tile.silverBars lotr:tile.slabDouble13:5 lotr:tile.slabDouble8:3 lotr:tile.slabSingle13:5,13 lotr:tile.slabSingle8:3,11 lotr:tile.stairsTauredainBrickGold lotr:tile.tauredainDartTrapGold lotr:tile.treasureGold lotr:tile.treasureSilver lotr:tile.wallStone4:3
 
+# Unpowered Light Weighted Pressure Plate - Euphoria Patches Redstone IPBR
+block.10313 = light_weighted_pressure_plate:0
+
+# Powered Light Weighted Pressure Plate - Euphoria Patches Redstone IPBR
+block.10315 = light_weighted_pressure_plate:1 light_weighted_pressure_plate:2 light_weighted_pressure_plate:3 light_weighted_pressure_plate:4 light_weighted_pressure_plate:5 light_weighted_pressure_plate:6 light_weighted_pressure_plate:7 light_weighted_pressure_plate:8 light_weighted_pressure_plate:9 light_weighted_pressure_plate:10 light_weighted_pressure_plate:11 light_weighted_pressure_plate:12 light_weighted_pressure_plate:13 light_weighted_pressure_plate:14 light_weighted_pressure_plate:15
+
 # Diamond Blocks
 block.10316 = diamond_block \
 \
 lotr:tile.blockGem:0,2,3,4,5,6,7,8
+
+# Diamond Non-Full Blocks (Modded Only)
+block.10317 =
 
 # Glowing Ores Diamond
 block.10320 = diamond_ore \
 \
 lotr:tile.oreGem:0,1,2,3,4,5,6
 
+# Glowing Ores Diamond Non-Full Block (Modded Only)
+block.10321 =
+
+# Deepslate Diamond Variant
+block.10324 =
+
+# Amethyst Blocks
+block.10328 = lotr:tile.blockGem:1
+
+# Amethyst Non-Full Blocks (Modded Only)
+block.10329 =
+
+# Amethyst Crystals
+block.10332 =
+
 # Emerald Blocks
 block.10336 = emerald_block \
 \
 lotr:tile.blockGem:9
+
+# Emerald Non-Full Blocks (Modded Only)
+block.10337 =
 
 # Glowing Ores Emerald
 block.10340 = emerald_ore \
 \
 lotr:tile.oreGem:7
 
+# Glowing Non-Full Emerald Ore (Modded Only)
+block.10341 =
+
+# Deepslate Variant
+block.10344 =
+
+# Azalea
+block.10349 =
+
 # Lapis Blocks
 block.10352 = lapis_block
 
+# Lapis Non-Full Blocks (Modded Only)
+block.10353 =
+
 # Glowing Ores Lapis
 block.10356 = lapis_ore
+
+# Deepslate Variant
+block.10360 =
+
+
+##### QUARTZ #####
+
 
 # Full Quartz Block
 block.10364 = quartz_block double_stone_slab:7,15 \
@@ -17065,6 +17424,9 @@ block.10372 = obsidian \
 \
 lotr:tile.brick4:4,14 lotr:tile.pillar2:12 lotr:tile.slabDouble13:6 lotr:tile.slabDouble8:4,6 lotr:tile.slabUtumnoDouble2:1 lotr:tile.slabUtumnoDouble:2,5 lotr:tile.tauredainDartTrapObsidian lotr:tile.utumnoBrick:4,5,7 lotr:tile.utumnoPillar:2
 
+# Obsidian Non-Full Blocks (Modded Only)
+block.10373 = lotr:tile.stairsDwarvenBrickObsidian lotr:tile.stairsTauredainBrickObsidian lotr:tile.stalactiteObsidian lotr:tile.wallStone4:4,6 lotr:tile.slabSingle8:4,6,12,14 lotr:tile.slabUtumnoSingle:2,5,10,13 lotr:tile.slabUtumnoSingle2:1,9 lotr:tile.slabSingle13:6,14 lotr:tile.stairsUtumnoBrickObsidian lotr:tile.stairsUtumnoTileObsidian lotr:tile.wallUtumno:2,4
+
 # Full Purpur Blocks
 block.10376 =
 
@@ -17074,14 +17436,41 @@ block.10379 =
 # Full Snow Blocks
 block.10380 = snow snow_layer:7,15
 
+# Non-Full Snow Blocks
+block.10381 =
+
 # Packed Ice
 block.10384 = packed_ice
+
+# Packed Ice Non-Full Blocks (Modded Only)
+block.10385 = lotr:tile.stalactiteIce
+
+# Blue Ice
+block.10388 =
+
+# Non-Full Blue Ice (Modded Only)
+block.10389 =
 
 # Carved Pumpkin
 block.10392 = pumpkin
 
+# Pumpkin Non-Full Blocks (Modded Only)
+block.10393 =
+
 # Jack o'Lantern
 block.10396 = lit_pumpkin
+
+# Non-Waterlogged Sea Pickle
+block.10401 =
+
+# Waterlogged Sea Pickle
+block.10404 =
+
+# Basalt Blocks
+block.10408 =
+
+# Basalt Non-Full Blocks (Modded Only)
+block.10409 =
 
 # Glowstone Blocks
 block.10412 = glowstone \
@@ -17100,22 +17489,59 @@ block.10419 = stone_slab:6 stone_slab:14 nether_brick_stairs
 # Red Nether Bricks Full Blocks
 block.10420 =
 
+# Red Nether Bricks Non-Full Blocks
+block.10421 =
+
+# Red Nether Slabs and Stairs
+block.10423 = quark:red_nether_brick_slab quark:red_nether_brick_stairs
+
 # Melon
 block.10424 = melon_block
 
+# Melon Non-Full Blocks (Modded Only)
+block.10425 =
+
 # Endstone Full Blocks
 block.10428 = end_stone
+
+# Endstone Non-Full Blocks
+block.10429 =
+
+# Endstone Slabs and Stairs
+block.10431 =
 
 # Terracotta
 block.10432 = hardened_clay stained_hardened_clay \
 \
 lotr:tile.brick3:10 lotr:tile.brick6:13 lotr:tile.clayTile lotr:tile.clayTileDyed lotr:tile.slabClayTileDouble lotr:tile.slabClayTileDyedDouble lotr:tile.slabClayTileDyedDouble2
 
+# Terracotta Non-Full Blocks (Modded Only)
+block.10433 = lotr:tile.ceramicMug lotr:tile.ceramicPlate lotr:tile.slabClayTileDyedSingle lotr:tile.slabClayTileDyedSingle2 lotr:tile.slabClayTileSingle lotr:tile.stairsClayTile lotr:tile.stairsClayTileDyedBlack lotr:tile.stairsClayTileDyedBlue lotr:tile.stairsClayTileDyedBrown lotr:tile.stairsClayTileDyedCyan lotr:tile.stairsClayTileDyedGray lotr:tile.stairsClayTileDyedGreen lotr:tile.stairsClayTileDyedLightBlue lotr:tile.stairsClayTileDyedLightGray lotr:tile.stairsClayTileDyedLime lotr:tile.stairsClayTileDyedMagenta lotr:tile.stairsClayTileDyedOrange lotr:tile.stairsClayTileDyedPink lotr:tile.stairsClayTileDyedPurple lotr:tile.stairsClayTileDyedRed lotr:tile.stairsClayTileDyedWhite lotr:tile.stairsClayTileDyedYellow lotr:tile.wallClayTile lotr:tile.wallClayTileDyed
+
 # Glazed Terracotta
 block.10436 =
 
+# Glazed Terracotta Non-Full Blocks (Modded Only)
+block.10437 =
+
+
+##### PRISMARINE #####
+
+
 # Prismarine Full Blocks
 block.10440 =
+
+# Prismarine Non-Full Blocks
+block.10441 =
+
+# Prismarine Slabs and Stairs
+block.10443 =
+
+# Dark Prismarine Full Blocks
+block.10444 =
+
+# Dark Prismarine Non-Full Blocks
+block.10447 =
 
 # Sea Lantern
 block.10448 =
@@ -17123,14 +17549,51 @@ block.10448 =
 # Magma Blocks
 block.10452 = lotr:tile.morgulCraftingTable lotr:tile.oreNaurite lotr:tile.oreStorage:10
 
+# Magma Non-Full Blocks (Modded Only)
+block.10453 =
+
 # Command Blocks
 block.10456 = command_block
 
 # Concrete Blocks
 block.10460 =
 
+# Concrete Non-Full Blocks (Modded Only)
+block.10461 =
+
 # Concrete Powder
 block.10464 = lotr:tile.oreStorage2:3 lotr:tile.oreStorage:13,14
+
+# Concrete Powder Non-Full Blocks (Modded Only)
+block.10465 =
+
+# Coral Full Blocks
+block.10468 = lotr:tile.coralReef
+
+# Coral Non-Full Blocks (Coral Fans...)
+block.10473 =
+
+# Crying Obsidian
+block.10476 =
+
+# Crying Obsidian Non-Full Blocks (Modded Only)
+block.10477 =
+##### BLACKSTONE #####
+
+# Blackstone Full Blocks
+block.10480 = lotr:tile.angmarCraftingTable lotr:tile.brick2:0,1,7,8,9,10,11 lotr:tile.brick4:6 lotr:tile.brick6:9,10,11,12 lotr:tile.brick:0,7 lotr:tile.dolGuldurCraftingTable lotr:tile.guldurilBrick:0,1,2,3,4,5,9 lotr:tile.pillar2:4 lotr:tile.pillar3 lotr:tile.pillar:7,9 lotr:tile.rock:0 lotr:tile.slabDouble10:7 lotr:tile.slabDouble12:7 lotr:tile.slabDouble14:1,3,4 lotr:tile.slabDouble2:2 lotr:tile.slabDouble3:3,4 lotr:tile.slabDouble4:4,5,6 lotr:tile.slabDouble5:1,3,4 lotr:tile.slabDouble9:4 lotr:tile.slabDouble:0,1 lotr:tile.slabUtumnoDouble2:2 lotr:tile.slabUtumnoDouble:0,3 lotr:tile.smoothStone:0 lotr:tile.urukCraftingTable lotr:tile.utumnoBrick:0,1,8 lotr:tile.utumnoPillar:0
+
+# Blackstone Non-Full Blocks
+block.10481 = lotr:tile.buttonMordorRock lotr:tile.pressurePlateMordorRock lotr:tile.wallStone2:0,1,7,8,9,10 lotr:tile.wallStone5:2,3 lotr:tile.wallStone:0,1,9 lotr:tile.wallUtumno:0,5
+
+# Blackstone Slabs and Stairs
+block.10483 = lotr:tile.stairsAngmarBrick lotr:tile.stairsAngmarBrickCracked lotr:tile.stairsAngmarBrickSnow lotr:tile.stairsBlackGondorBrick lotr:tile.stairsDolGuldurBrick lotr:tile.stairsDolGuldurBrickCracked lotr:tile.stairsDolGuldurBrickMossy lotr:tile.stairsMordorBrick lotr:tile.stairsMordorBrickCracked lotr:tile.stairsMordorRock lotr:tile.stairsUrukBrick lotr:tile.slabSingle:0,1,8,9 lotr:tile.slabSingle2:2,10 lotr:tile.slabSingle3:3,4,11,12 lotr:tile.slabSingle4:4,5,6,12,13,14 lotr:tile.slabSingle5:1,3,4,9,11,12 lotr:tile.slabSingle9:4,12 lotr:tile.slabUtumnoSingle:0,3,8,11 lotr:tile.slabSingle10:7,15 lotr:tile.slabSingle12:7,15 lotr:tile.slabUtumnoSingle2:2,10 lotr:tile.slabSingle14:1,3,4,9,11,12 lotr:tile.stairsUtumnoBrickFire lotr:tile.stairsUtumnoTileFire
+
+# Glowing Gilded Blackstone
+block.10484 =
+
+# Glowing Gilded Blackstone (Modded Only)
+block.10485 =
 
 # Top water Plants (LilyPads, Waterlilies, Duckweed, etc.)
 block.10489 = waterlily \
@@ -17168,14 +17631,31 @@ block.10521 = cactus
 # Unpowered Noteblock
 block.10524 = noteblock jukebox
 
+# Powered Noteblock
+block.10526 =
+
+# Soul Torch
+block.10528 =
+
+##### MUSHROOM BLOCKS #####
+
 # Brown Mushroom Blocks
 block.10532 = brown_mushroom_block:0,1,2,3,4,5,6,7,8,9,11,12,13,14
+
+# Brown Mushroom Non-Full Blocks (Modded Only)
+block.10533 =
 
 # Red Mushroom Blocks
 block.10536 = red_mushroom_block:0,1,2,3,4,5,6,7,8,9,11,12,13,14
 
 # Mushroom Stem Blocks
 block.10540 = brown_mushroom_block:10,15 red_mushroom_block:10,15
+
+# Mushroom Stem Non-Full Blocks (Modded Only)
+block.10541 =
+
+# Glow Lichen
+block.10544 =
 
 # Enchanting Table
 block.10548 = enchanting_table
@@ -17186,11 +17666,47 @@ block.10554 = end_portal_frame:0,1,2,3,8,9,10,11,12,13,14,15
 # End Portal Frame With Ender Eye
 block.10556 = end_portal_frame:4,5,6,7
 
+# End Portal Frame With Ender Eye Full Block (Modded Only)
+block.10557 =
+
+# Lantern
+block.10560 =
+
+# Hanging Lantern
+block.10562 =
+
+# Soul Lantern
+block.10564 =
+
+# Turtle Egg
+block.10569 =
+
 # Dragon Egg
 block.10572 = dragon_egg
 
+# Lit Smoker (Turned On)
+block.10576 =
+
+# Lit Blast Furnace (Turned On)
+block.10580 = lotr:tile.hobbitOven:10,11,12,13
+
 # Coal Block
 block.10584 = coal_block
+
+# Coal Non-Full Blocks (Modded Only)
+block.10585 =
+
+# Respawn Anchor 0 Charge (No Glowstone)
+block.10588 =
+
+# Respawn Anchor Charges (Has Glowstone)
+block.10592 =
+
+# Redstone Dust (Wire) Any Power Level
+block.10596 = redstone_wire:1 redstone_wire:2 redstone_wire:3 redstone_wire:4 redstone_wire:5 redstone_wire:6 redstone_wire:7 redstone_wire:8 redstone_wire:9 redstone_wire:10 redstone_wire:11 redstone_wire:12 redstone_wire:13 redstone_wire:14 redstone_wire:15
+
+# Redstone Dust (Wire) 0 Power Level
+block.10601 = redstone_wire:0
 
 # Redstone Torch Lit (Turned On)
 block.10604 = redstone_torch
@@ -17207,6 +17723,18 @@ block.10612 = redstone_ore
 # Redstone Ore Lit
 block.10616 = lit_redstone_ore
 
+# Deepslate Redstone Ore Unlit
+block.10620 =
+
+# Deepslate Redstone Ore Lit
+block.10624 =
+
+# Cave Vines Berries False
+block.10629 =
+
+# Cave Vines Berries True
+block.10632 =
+
 # Redstone Lamp Unlit
 block.10636 = redstone_lamp
 
@@ -17222,8 +17750,27 @@ block.10645 = unpowered_repeater unpowered_comparator:0,1,2,3
 # Unpowered Compartor and in subtract mode
 block.10646 = unpowered_comparator:4,5,6,7
 
+# Shroomlight
+block.10648 =
+
+# Shroomlight Non-Full Blocks (Modded Only)
+block.10649 =
+
+# Campfire Lit
+block.10652 =
+
+# Soul Campfire Lit
+block.10656 =
+
+# Campfires Unlit
+block.10661 =
+
+
 # Observer
 block.10664 =
+
+# Observer Non-Full Blocks (Modded Only)
+block.10665 =
 
 # Wool
 block.10668 = wool:0,1,2,3,4,6,7,8,9,10,12,13,14,15 \
@@ -17239,15 +17786,67 @@ block.10671 = tripwire
 # Full Bone Blocks
 block.10672 = lotr:tile.boneBlock lotr:tile.slabBoneDouble
 
+# Non-Full Bone Blocks (Modded Only)
+block.10673 = lotr:tile.slabBoneSingle lotr:tile.stairsBone lotr:tile.wallBone
+
+# Barrel \ Bee Blocks
+block.10676 =
+
+# Barrel Non-Full Blocks \ Bee Non-Full Blocks
+block.10677 = lotr:tile.barrel
+
+
+##### FROGLIGHTS #####
+
+
+# Ochre Froglight
+block.10680 =
+
+# Verdant Froglight
+block.10684 =
+
+# Pearlescent Froglight
+block.10688 =
+
+# Reinforced Deepslate
+block.10692 =
+
+
+##### SCULK BLOCKS #####
+
+# Sculk Block
+block.10696 =
+
+# Sculk Non-Full Blocks (Modded Only)
+block.10697 =
+
+# Sculk Shrieker
+block.10700 =
+
+# Active Sculk Sensor
+block.10704 =
+
 # Mob Spawner
 block.10708 = mob_spawner \
 \
 lotr:tile.mobSpawner
 
+# Tuff Blocks
+block.10712 =
+
+# Tuff Non-Full Blocks
+block.10713 =
+
+# Tuff Stairs and Slabs
+block.10715 =
+
 # Clay Full Blocks
 block.10716 = clay \
 \
 lotr:tile.moredainCraftingTable lotr:tile.redClay lotr:tile.slabDouble14:2 lotr:tile.slabDouble7:0
+
+# Clay Non-Full Blocks (Modded Only)
+block.10717 = lotr:tile.slabSingle14:2,10 lotr:tile.slabSingle7:0,8 lotr:tile.stairsMoredainBrick lotr:tile.stairsMorwaithBrickCracked lotr:tile.wallStone2:15 lotr:tile.wallStone5:4
 
 # Ladders
 block.10721 = ladder \
@@ -17259,16 +17858,82 @@ block.10724 = gravel \
 \
 lotr:tile.mordorGravel lotr:tile.obsidianGravel lotr:tile.slabDoubleGravel
 
+# Gravel Non-Full Blocks (Modded Only)
+block.10725 = lotr:tile.slabSingleGravel
+
 # Flower Pot - No Subsurface Scattering
 block.10729 = flower_pot \
 \
 lotr:tile.flowerPot
 
+# Flower Pot - Subsurface Scattering
+block.10733 =
+
+# Flower Pot - Subsurface Scattering, Flowers - Euphoria Patches Emissive Flowers
+block.10735 =
+
 # Jigsaw Block
 block.10736 =
 
+# Pitcther Crop
+block.10737 =
+
+# Chain
+block.10741 = lotr:tile.orcChain
+
 # Soul Sand
 block.10744 = soul_sand
+
+# Dried Kelp Blocks
+block.10748 =
+
+# Dried Kelp Non-Full Blocks (Modded Only)
+block.10749 =
+
+# Bamboo
+block.10753 =
+
+# Bamboo Full Blocks
+block.10756 =
+
+# Bamboo Non-Full Blocks
+block.10757 =
+
+# Bamboo Stairs and Slabs
+block.10759 =
+
+# Cherry Wood Full Blocks
+block.10760 = lotr:tile.planks:6 lotr:tile.woodSlabDouble:6
+
+# Cherry Wood Non-Full Blocks
+block.10761 =
+
+# Cherry Wood Stairs and Slabs
+block.10763 = lotr:tile.stairsCherry lotr:tile.woodSlabSingle:6,14
+
+# Cherry Wood Logs
+block.10764 = lotr:tile.fruitWood:2,6,10,14 lotr:tile.woodBeamFruit:2,6,10,14
+
+# Cherry Non-Full Logs (Modded Only)
+block.10765 = lotr:tile.fenceGateCherry lotr:tile.trapdoorCherry lotr:tile.fence:6
+
+# Torchflower
+block.10769 =
+
+# Potted Torchflower
+block.10773 =
+
+# Nether Fungus - Euphoria Patches Disable Interactive Foliage
+block.10776 =
+
+# Potted nether fungus
+block.10780 =
+
+# Calibrated Sculk Sensor Not Active
+block.10784 =
+
+# Calibrated Sculk Sensor Active
+block.10788 =
 
 # Oak Door Unpowered - Euphoria Patches Redstone IPBR
 block.10793 = wooden_door \
@@ -17308,6 +17973,36 @@ block.10813 = lotr:tile.doorCharred lotr:tile.doorDarkOak lotr:tile.doorGreenOak
 # Dark Oak Door Powered - Euphoria Patches Redstone IPBR
 block.10815 =
 
+# Mangrove Door Unpowered - Euphoria Patches Redstone IPBR
+block.10817 =
+
+# Mangrove Door Powered - Euphoria Patches Redstone IPBR
+block.10819 =
+
+# Crimson Door Unpowered - Euphoria Patches Redstone IPBR
+block.10821 =
+
+# Crimson Door Powered - Euphoria Patches Redstone IPBR
+block.10823 =
+
+# Warped Door Unpowered - Euphoria Patches Redstone IPBR
+block.10825 =
+
+# Warped Door Powered - Euphoria Patches Redstone IPBR
+block.10827 =
+
+# Bamboo Door Unpowered - Euphoria Patches Redstone IPBR
+block.10829 =
+
+# Bamboo Door Powered - Euphoria Patches Redstone IPBR
+block.10831 =
+
+# Cherry Door Unpowered - Euphoria Patches Redstone IPBR
+block.10833 = lotr:tile.doorCherry
+
+# Cherry Door Powered - Euphoria Patches Redstone IPBR
+block.10835 =
+
 # Brewing Stand
 block.10836 = brewing_stand
 
@@ -17329,10 +18024,58 @@ block.10845 = carpet:5
 # Blue Concrete - Euphoria Patches Euphoria Patches Blue Screen
 block.10846 =
 
+# Crafter
+block.10848 =
+
+# Copper Bulb - Normal And Exposed - Lit
+block.10852 =
+
+# Copper Bulb - Normal And Exposed - Unlit
+block.10854 =
+
+# Copper Bulb - Weathered And Oxidized - Lit
+block.10856 =
+
+# Copper Bulb - Weathered And Oxidized - Unlit
+block.10858 =
+
+# Copper Door Unpowered - Euphoria Patches Redstone IPBR
+block.10861 =
+
+# Copper Door Powered - Euphoria Patches Redstone IPBR
+block.10863 =
+
+# Copper Trapdoor Unpowered - Euphoria Patches Redstone IPBR
+block.10865 =
+
+# Copper Trapdoor Powered - Euphoria Patches Redstone IPBR
+block.10867 =
+
+# Trial Spawner Active
+block.10868 =
+
+# Trial Spawner Inactive
+block.10872 =
+
+# Trial Spawner Cooldown
+block.10873 =
+
+# Trial Spawner Ominous Active
+block.10876 =
+
+# Nether Vines with ACT Light
+block.10884 =
+
+# Nether Vines without ACT Light
+block.10885 =
+
 # Hay Bale
 block.10888 = hay_block \
 \
 lotr:tile.slabDoubleThatch lotr:tile.thatch
+
+# Hay Non-Full Blocks (Modded Only)
+block.10889 = lotr:tile.reedBars lotr:tile.slabSingleThatch lotr:tile.stairsReed lotr:tile.stairsThatch lotr:tile.thatchFloor
 
 # Normal Iron Door - Euphoria Patches Redstone IPBR
 block.10891 = iron_door
@@ -17340,14 +18083,122 @@ block.10891 = iron_door
 # Powered Iron Door - Euphoria Patches Redstone IPBR
 block.10893 =
 
+# Unpowered Iron Trapdoor - Euphoria Patches Redstone IPBR
+block.10897 = iron_trapdoor:0 iron_trapdoor:1 iron_trapdoor:2 iron_trapdoor:3 iron_trapdoor:8 iron_trapdoor:9 iron_trapdoor:10 iron_trapdoor:11
+
+# Powered Iron Trapdoor - Euphoria Patches Redstone IPBR
+block.10899 = iron_trapdoor:4 iron_trapdoor:5 iron_trapdoor:6 iron_trapdoor:7 iron_trapdoor:12 iron_trapdoor:13 iron_trapdoor:14 iron_trapdoor:15
+
+
+##### CANDLES #####
+
+# Normal Candles
+block.10900 =
+
+# Red Candles
+block.10902 =
+
+# Orange Candles
+block.10904 =
+
+# Yellow Candles
+block.10906 =
+
+# Lime Candles
+block.10908 =
+
+# Green Candles
+block.10910 =
+
+# Cyan Candles
+block.10912 =
+
+# Light Blue Candles
+block.10914 =
+
+# Blue Candles
+block.10916 =
+
+# Purple Candles
+block.10918 =
+
+# Magenta Candles
+block.10920 =
+
+# Pink Candles
+block.10922 =
+
+# Pale hanging Moss - Euphoria Patches Interactive Foliage
+block.10923 =
+
+# Moss block
+block.10924 =
+
+# Moss Carpet
+block.10925 =
+
+# Pale Moss Carpet
+block.10927 =
+
+# Pale Oak Wood Full Blocks
+block.10928 =
+
+# Pale Oak Wood Non-Full Blocks
+block.10929 =
+
+# Pale Oak Wood Slabs and Stairs
+block.10931 =
+
+# Pale Oak Log Full Blocks
+block.10932 =
+
+# Pale Oak Log Non-Full Blocks (Modded Only)
+block.10933 =
+
+# Pale Oak Door
+block.10937 =
+
+# Resin Full Blocks
+block.10940 =
+
+# Resin Non-Full Blocks
+block.10941 =
+
+# Creaking Heart Inactive
+block.10944 =
+
+# Creaking Heart Active
+block.10948 =
+
 # All snow layers except layer 8
 block.10953 = snow_layer:0,1,2,3,4,5,6,8,9,10,11,12,13,14
+
+# Target 0 Power
+block.10956 =
+
+# Target Powered
+block.10960 =
 
 # Sponge
 block.10964 = sponge
 
 # Wet Sponge
 block.10968 =
+
+# Firefly Bush
+block.10972 =
+
+# Open Eye Blossom
+block.10976 =
+
+# Pottet Open Eye Blossom
+block.10980 =
+
+# Copper Torch
+block.10984 =
+
+# Copper Lantern
+block.10988 =
 
 # Solid Blocks With No Properties
 block.11110 = tnt \
@@ -17359,8 +18210,78 @@ block.11111 = air barrier piston_extension structure_void nether_wart red_mushro
 \
 lotr:tile.appleCrumble lotr:tile.banana lotr:tile.bananaCake lotr:tile.berryPie lotr:tile.cherryPie lotr:tile.dalishPastry lotr:tile.date lotr:tile.elvenPortal lotr:tile.entJar lotr:tile.hithlainLadder lotr:tile.lemonCake lotr:tile.marshLights lotr:tile.marzipanBlock lotr:tile.morgulPortal lotr:tile.plate lotr:tile.rope lotr:tile.skullCup lotr:tile.utumnoPortal lotr:tile.utumnoReturnLight lotr:tile.utumnoReturnPortal
 
+# No Parallax Occlusion Mapping (POM)
+block.20000 =
+
+
+##### MODDED COLORED LIGHT SOURCES #####
+
+
+# PLEASE READ!!!
+# These IDs should only be used for light sources that don’t work with the vanilla block IDs.
+# These IDs add primarily colored lighting if "Advanced Colored Lighting" is enabled.
+# Additionally, they add emission based on the brightness of the texture and light level when using Iris.
+
+# To add support for the handheld item, add these Ids to 44043+ in item.properties.
+
+# IMPORTANT: Use vanilla IDs first if they work better!!
+
+# White Modded Light Source  - Also used For Black / Gray
+block.21000 =
+
+# Brown Modded Light Source
+block.21002 =
+
+# Red Modded Light Source
+block.21004 =
+
+# Orange Modded Light Source
+block.21006 =
+
+# Yellow Modded Light Source
+block.21008 =
+
+# Lime Modded Light Source
+block.21010 =
+
+# Green Modded Light Source
+block.21012 =
+
+# Cyan Modded Light Source
+block.21014 =
+
+# Light Blue Modded Light Source
+block.21016 =
+
+# Blue Modded Light Source
+block.21018 =
+
+# Purple Modded Light Source
+block.21020 =
+
+# Magenta Modded Light Source
+block.21022 =
+
+# Pink Modded Light Source
+block.21024 =
+
+# Declared but unused in Complementary itself
+block.30000 =
+
+# Declared but unused in Complementary itself
+block.30004 =
+
+# Tinted Glass Blocks
+block.30008 =
+
+# Tinted Glass Panes (Modded Only)
+block.30009 =
+
 # Slime Blocks
-block.30012 = slime
+block.30012 =
+
+# Honey Block
+block.30016 =
 
 # Nether Portal
 block.30020 = portal
@@ -17539,15 +18460,19 @@ block.32008 = glass \
 \
 lotr:tile.glass
 
+# Glass Without ACL Connected Glass
+block.32009 =
+
 # Glass Pane
 block.32012 = glass_pane \
 \
 lotr:tile.butterflyJar lotr:tile.glassBottle lotr:tile.glassPane lotr:tile.wineGlass
 
+# Glass Pane Without ACL Connected Glass
+block.32013 =
+
 # Beacon
 block.32016 = beacon
-
-
 
 #endif
 


### PR DESCRIPTION
Created by copying the pre 1.7.10 seperated 1.12 section and removing all modded blocks and all 1.8 and newer vanilla blocks