### PR TITLE
Update entity.properties

### DIFF
--- a/entity.properties
+++ b/entity.properties
@@ -42,7 +42,7 @@
 #if MC_VERSION >= 11100
 
 # End Crystal
-entity.50000 = end_crystal
+entity.50000 = end_crystal ender_crystal
 
 # Lightning Bolt
 entity.50004 = lightning_bolt \
@@ -52,7 +52,7 @@ ars_nouveau:an_lightning
 entity.50008 =
 
 # Iron Golem
-entity.50012 = iron_golem \
+entity.50012 = iron_golem villager_golem \
 \
 ad_astra:lander ad_astra:tier_1_rocket ad_astra:tier_2_rocket ad_astra:tier_3_rocket ad_astra:tier_4_rocket \
 \
@@ -175,7 +175,7 @@ betternether:naga \
 born_in_chaos_v1:lifestealer born_in_chaos_v1:lifestealer_true_form
 
 # Experience Orbs
-entity.50072 = experience_orb \
+entity.50072 = experience_orb xp_orb \
 \
 adventurez:void_bullet \
 \


### PR DESCRIPTION
Adds missing entity IDs to the `entity.properties` file for Minecraft version 1.12.2