### PR TITLE
Partial support for Hbm's Nuclear Tech Mod and NTM: Space

### DIFF
--- a/addedMods.md
+++ b/addedMods.md
@@ -262,6 +262,7 @@ Here we can keep track of what mods have been added and what version a contribut
 | [Handcrafted](https://modrinth.com/mod/handcrafted) | 4.0.3 | Fully Added |
 | [Hardcore Ender Expansion](https://www.curseforge.com/minecraft/mc-mods/hardcore-ender-expansion) | 1.12.16-GTNH | Miniscule | # Various plants
 | [Haunted Harvest](https://modrinth.com/mod/haunted-harvest) | | Fully Added |
+| [Hbm's Nuclear Tech Mod](https://modrinth.com/mod/ntm) | | Partial Support |
 | [Healing Pretty Good](https://modrinth.com/mod/healing-pretty-good) | 1.5.3 | Fully Added | # Added both the old and new IDs for this mod.
 | [Hearth & Home](https://modrinth.com/mod/hearth-and-home) | 2.0.3 | Fully Added |
 | [Hephaestus](https://modrinth.com/mod/hephaestus) | 3.6.4.287 | Fully Added |
@@ -349,6 +350,7 @@ Here we can keep track of what mods have been added and what version a contribut
 | [Netherending Ores](https://www.curseforge.com/minecraft/mc-mods/netherending-ores) | 1.4.2 | Fully Added |
 | [Nosiphus Custom Blocks](https://www.curseforge.com/minecraft/mc-mods/nosiphus-custom-blocks) | 2026.01.02 | Partial Support |
 | [Nosiphus Furniture Mod](https://www.curseforge.com/minecraft/mc-mods/nosiphus-furniture-mod) | 2026.01.30 | Partial Support |
+| [NTM Space](https://modrinth.com/mod/ntmspace) | | Partial Support | # Fork of Hbm's Nuclear Tech Mod
 | [Nyx](https://www.curseforge.com/minecraft/mc-mods/nyx) | 1.4.2 | Fully Added |
 | [Occultism](https://modrinth.com/mod/occultism) | | Miniscule |
 | [Ocean's Delight](https://modrinth.com/mod/oceans-delight) | 1.0.2 | Miniscule |

--- a/blockProperties/1.7.10/block.properties
+++ b/blockProperties/1.7.10/block.properties
@@ -63,6 +63,8 @@ block.10003 = yellow_flower red_flower \
 \
 etfuturum:cornflower etfuturum:lily_of_the_valley etfuturum:rose \
 \
+hbm:tile.plant_flower:0 \
+\
 lotr:tile.asphodel lotr:tile.bluebell lotr:tile.doubleFlower:0,2,3 lotr:tile.dwarfHerb lotr:tile.elanor lotr:tile.fangornPlant lotr:tile.flax lotr:tile.flaxPlant lotr:tile.haradFlower lotr:tile.lavender lotr:tile.marigold lotr:tile.morgulFlower lotr:tile.niphredil lotr:tile.pipeweedPlant lotr:tile.rhunFlower lotr:tile.shireHeather lotr:tile.simbelmyne lotr:tile.tallGrass:3
 
 # Short Foliage / Foliage Lower Half
@@ -102,6 +104,8 @@ harvestcraft:berrygarden harvestcraft:desertgarden harvestcraft:gourdgarden harv
 \
 harvestthenether:bloodleafCrop harvestthenether:fleshrootCrop harvestthenether:glowflowerCrop harvestthenether:marrowberryCrop harvestthenether:netherSapling \
 \
+hbm:tile.plant_flower:1,2,3,4,5,6,7 hbm:tile.plant_tall:0,1,2,3 hbm:tile.plant_dead hbm:tile.rubber_plant hbm:tile.rubber_tall hbm:tile.crop_strawberry hbm:tile.crop_mint hbm:tile.crop_paraffin hbm:tile.crop_coffee hbm:tile.crop_tea hbm:tile.sapling \
+\
 lotr:tile.aridGrass lotr:tile.athelas lotr:tile.blackroot lotr:tile.clover lotr:tile.cornStalk lotr:tile.corruptMallorn lotr:tile.deadMarshPlant lotr:tile.doubleFlower:1 lotr:tile.fruitSapling lotr:tile.grapevineRed lotr:tile.grapevineWhite lotr:tile.leek lotr:tile.lettuce lotr:tile.mordorGrass lotr:tile.mordorThorn lotr:tile.morgulShroom lotr:tile.pipeweed lotr:tile.sapling lotr:tile.sapling2 lotr:tile.sapling3 lotr:tile.sapling4 lotr:tile.sapling5 lotr:tile.sapling6 lotr:tile.sapling7 lotr:tile.sapling8 lotr:tile.sapling9 lotr:tile.tallGrass:0,1,2,4,5 lotr:tile.turnip lotr:tile.yam \
 \
 miscutils:blockPineSapling miscutils:blockRainforestOakSapling \
@@ -114,6 +118,8 @@ witchery:plantmine:0,1,2,3,4,5,6,7,8,9,10,11 witchery:witchsapling:0,1,2
 block.10007 = leaves:1,3,5,7,9,11,13,15 leaves2:0,4,8,12 \
 \
 etfuturum:leaves \
+\
+hbm:tile.waste_leaves hbm:tile.pet_leaves hbm:tile.rubber_leaves \
 \
 lotr:tile.fruitLeaves lotr:tile.leaves lotr:tile.leaves2 lotr:tile.leaves3 lotr:tile.leaves4 lotr:tile.leaves5 lotr:tile.leaves6 lotr:tile.leaves7 lotr:tile.leaves8 lotr:tile.leaves9
 
@@ -164,12 +170,16 @@ GalacticraftMars:tile.cavernVines \
 \
 TwilightForest:tile.TFPlant:13,14 \
 \
+hbm:tile.vinyl_vine \
+\
 lotr:tile.mirkVines lotr:tile.willowVines
 
 # Non-Waving Foliage - Euphoria Patches Interactive Foliage
 block.10015 = lotr:tile.fallenLeaves lotr:tile.fallenLeavesLOTR lotr:tile.fallenLeavesLOTR2 lotr:tile.fallenLeavesLOTR3 lotr:tile.driedReeds lotr:tile.reeds lotr:tile.mordorMoss \
 \
 BiomesOPlenty:bamboo \
+\
+hbm:tile.plant_reeds hbm:tile.laythe_seagrass hbm:tile.laythe_glowgrass hbm:tile.plant_tall_laythe hbm:tile.laythe_kelp \
 \
 witchery:bramble:0,1 witchery:voidbramble
 
@@ -184,7 +194,9 @@ lotr:tile.webUngoliant
 block.10019 = etfuturum:pink_petals
 
 # Tall Foliage Upper Half
-block.10021 = double_plant:8,9,10,11
+block.10021 = double_plant:8,9,10,11 \
+\
+hbm:tile.plant_tall:8,9,10,11
 
 # Tall Flowers Upper half - Euphoria Patches Emissive Flowers
 block.10023 = lotr:tile.doubleFlower:8,9,10,11
@@ -986,6 +998,8 @@ block.10368 = quartz_ore
 # Obsidian Full Blocks
 block.10372 = obsidian \
 \
+etfuturum:crying_obsidian \
+\
 lotr:tile.brick4:4,14 lotr:tile.pillar2:12 lotr:tile.slabDouble13:6 lotr:tile.slabDouble8:4,6 lotr:tile.slabUtumnoDouble2:1 lotr:tile.slabUtumnoDouble:2,5 lotr:tile.tauredainDartTrapObsidian lotr:tile.utumnoBrick:4,5,7 lotr:tile.utumnoPillar:2
 
 # Obsidian Non-Full Blocks (Modded Only)
@@ -1040,6 +1054,8 @@ block.10409 =
 block.10412 = glowstone \
 \
 etfuturum:light \
+\
+hbm:tile.reinforced_light hbm:tile.asphalt_light \
 \
 lotr:tile.brick3:12 lotr:tile.oreGlowstone lotr:tile.oreGulduril lotr:tile.oreStorage:6,11
 
@@ -1146,10 +1162,12 @@ lotr:tile.oreStorage2:3 lotr:tile.oreStorage:13,14
 block.10465 =
 
 # Coral Full Blocks
-block.10468 = lotr:tile.coralReef
+block.10468 = hbm:tile.laythe_coral_block \
+\
+lotr:tile.coralReef
 
 # Coral Non-Full Blocks (Coral Fans...)
-block.10473 =
+block.10473 = hbm:tile.laythe_coral
 
 # Crying Obsidian
 block.10476 =
@@ -1324,7 +1342,9 @@ block.10620 = etfuturum:deepslate_redstone_ore
 block.10624 = etfuturum:deepslate_lit_redstone_ore
 
 # Cave Vines Berries False
-block.10629 = etfuturum:cave_vine:0 etfuturum:cave_vine_plant:0
+block.10629 = etfuturum:cave_vine:0 etfuturum:cave_vine_plant:0 \
+\
+hbm:tile.vine_phosphor
 
 # Cave Vines Berries True
 block.10632 = etfuturum:cave_vine:1 etfuturum:cave_vine_plant:1
@@ -1482,7 +1502,9 @@ block.10741 = etfuturum:chain \
 lotr:tile.orcChain
 
 # Soul Sand
-block.10744 = soul_sand
+block.10744 = soul_sand \
+\
+etfuturum:soul_soil
 
 # Dried Kelp Blocks
 block.10748 =
@@ -1863,28 +1885,28 @@ block.20000 =
 # IMPORTANT: Use vanilla IDs first if they work better!!
 
 # White Modded Light Source  - Also used For Black / Gray
-block.21000 =
+block.21000 = hbm:tile.spotlight_fluoro hbm:tile.spotlight_halogen
 
 # Brown Modded Light Source
 block.21002 =
 
 # Red Modded Light Source
-block.21004 =
+block.21004 = hbm:tile.fire_digamma
 
 # Orange Modded Light Source
-block.21006 =
+block.21006 = hbm:tile.block_meteor_molten hbm:tile.ore_nether_coal hbm:tile.ore_nether_smoldering hbm:tile.geysir_nether hbm:tile.brick_jungle_lava hbm:tile.ore_volcano hbm:tile.machine_furnace_brick_on hbm:tile.machine_rtg_furnace_on
 
 # Yellow Modded Light Source
 block.21008 =
 
 # Lime Modded Light Source
-block.21010 =
+block.21010 = hbm:tile.mush_block
 
 # Green Modded Light Source
-block.21012 =
+block.21012 = hbm:tile.lamp_tritium_green_on hbm:tile.mush hbm:tile.mush_block_stem hbm:tile.waste_mycelium hbm:tile.brick_jungle_ooze hbm:tile.machine_difurnace_rtg_on hbm:tile.balefire
 
 # Cyan Modded Light Source
-block.21014 =
+block.21014 = hbm:tile.lamp_tritium_blue_on hbm:tile.lamp_demon hbm:tile.hev_battery
 
 # Light Blue Modded Light Source
 block.21016 =
@@ -1899,7 +1921,7 @@ block.21020 = campfirebackport:foxfire_campfire
 block.21022 = campfirebackport:shadow_campfire
 
 # Pink Modded Light Source
-block.21024 =
+block.21024 = hbm:tile.brick_jungle_mystic
 
 # Declared but unused in Complementary itself
 block.30000 =
@@ -1968,6 +1990,8 @@ lotr:tile.stainedGlassPane:3
 # Yellow Stained Glass
 block.31008 = minecraft:stained_glass:4 \
 \
+hbm:tile.glass_uranium \
+\
 lotr:tile.stainedGlass:4
 
 # Yellow Stained Glass Panes
@@ -1977,6 +2001,8 @@ lotr:tile.stainedGlassPane:4
 
 # Lime Stained Glass
 block.31010 = minecraft:stained_glass:5 \
+\
+hbm:tile.glass_trinitite \
 \
 lotr:tile.stainedGlass:5
 
@@ -2018,10 +2044,14 @@ lotr:tile.stainedGlassPane:8
 # Cyan Stained Glass
 block.31018 = minecraft:stained_glass:9 \
 \
+hbm:tile.reinforced_laminate \
+\
 lotr:tile.stainedGlass:9
 
 # Cyan Stained Glass Panes
 block.31019 = minecraft:stained_glass_pane:9 \
+\
+hbm:tile.reinforced_laminate_pane \
 \
 lotr:tile.stainedGlassPane:9
 
@@ -2068,6 +2098,8 @@ lotr:tile.stainedGlassPane:13
 # Red Stained Glass
 block.31028 = minecraft:stained_glass:14 \
 \
+hbm:tile.glass_polonium \
+\
 lotr:tile.stainedGlass:14
 
 # Red Stained Glass Panes
@@ -2077,6 +2109,8 @@ lotr:tile.stainedGlassPane:14
 
 # Black Stained Glass
 block.31030 = minecraft:stained_glass:15 \
+\
+hbm:tile.glass_ash \
 \
 lotr:tile.stainedGlass:15
 
@@ -2101,7 +2135,7 @@ block.32008 = glass \
 lotr:tile.glass
 
 # Glass Without ACL Connected Glass
-block.32009 =
+block.32009 = hbm:tile.glass_boron hbm:tile.glass_lead hbm:tile.glass_quartz hbm:tile.glass_polarized hbm:tile.reinforced_glass
 
 # Glass Pane
 block.32012 = glass_pane \
@@ -2109,7 +2143,7 @@ block.32012 = glass_pane \
 lotr:tile.butterflyJar lotr:tile.glassBottle lotr:tile.glassPane lotr:tile.wineGlass
 
 # Glass Pane Without ACL Connected Glass
-block.32013 =
+block.32013 = hbm:tile.reinforced_glass_pane
 
 # Beacon
 block.32016 = beacon \

--- a/blockProperties/1.7.10/block.properties
+++ b/blockProperties/1.7.10/block.properties
@@ -1894,7 +1894,7 @@ block.21002 =
 block.21004 = hbm:tile.fire_digamma
 
 # Orange Modded Light Source
-block.21006 = hbm:tile.block_meteor_molten hbm:tile.ore_nether_coal hbm:tile.ore_nether_smoldering hbm:tile.geysir_nether hbm:tile.brick_jungle_lava hbm:tile.ore_volcano hbm:tile.machine_furnace_brick_on hbm:tile.machine_rtg_furnace_on
+block.21006 = hbm:tile.block_meteor_molten hbm:tile.ore_nether_coal hbm:tile.ore_nether_smoldering hbm:tile.geysir_nether hbm:tile.brick_jungle_lava hbm:tile.ore_volcano hbm:tile.machine_furnace_brick_on hbm:tile.machine_rtg_furnace_on hbm:tile.block_pu238
 
 # Yellow Modded Light Source
 block.21008 =

--- a/item.properties
+++ b/item.properties
@@ -247,6 +247,8 @@ extshape:glowstone_button extshape:glowstone_fence extshape:glowstone_fence_gate
 \
 extshape_blockus:blaze_lantern_button extshape_blockus:blaze_lantern_fence extshape_blockus:blaze_lantern_fence_gate extshape_blockus:blaze_lantern_pressure_plate extshape_blockus:blaze_lantern_quarter_piece extshape_blockus:blaze_lantern_slab extshape_blockus:blaze_lantern_stairs extshape_blockus:blaze_lantern_vertical_quarter_piece extshape_blockus:blaze_lantern_vertical_slab extshape_blockus:blaze_lantern_vertical_stairs extshape_blockus:blaze_lantern_wall extshape_blockus:rainbow_glowstone_button extshape_blockus:rainbow_glowstone_fence extshape_blockus:rainbow_glowstone_fence_gate extshape_blockus:rainbow_glowstone_pressure_plate extshape_blockus:rainbow_glowstone_quarter_piece extshape_blockus:rainbow_glowstone_slab extshape_blockus:rainbow_glowstone_stairs extshape_blockus:rainbow_glowstone_vertical_quarter_piece extshape_blockus:rainbow_glowstone_vertical_slab extshape_blockus:rainbow_glowstone_vertical_stairs extshape_blockus:rainbow_glowstone_wall \
 \
+hbm:tile.reinforced_light hbm:tile.asphalt_light \
+\
 mcwlights:covered_garden_light mcwlights:glowstone_slab mcwlights:redstone_lamp_slab mcwlights:round_garden_light mcwlights:striped_garden_light mcwlights:thin_garden_light mcwlights:tower_garden_light \
 \
 moglowstone:brick_glowstone_block moglowstone:lamp_glowstone_block \
@@ -765,6 +767,8 @@ createframed:framed_radon_lamp_orange \
 \
 fossilslegacy:orange_cultivator fossilslegacy:time_machine \
 \
+hbm:tile.block_meteor_molten hbm:tile.ore_nether_coal hbm:tile.ore_nether_smoldering hbm:tile.geysir_nether hbm:tile.brick_jungle_lava hbm:tile.ore_volcano \
+\
 hearth_and_home:orange_paper_lantern \
 \
 mcwlights:lava_lamp mcwlights:orange_ceiling_light mcwlights:orange_lamp mcwlights:orange_paper_lamp \
@@ -863,6 +867,8 @@ createframed:framed_radon_lamp_lime \
 \
 fossilslegacy:lime_cultivator \
 \
+hbm:tile.mush_block \
+\
 hearth_and_home:lime_paper_lantern \
 \
 iceandfire:pixie_jar_3 \
@@ -914,6 +920,8 @@ fossilslegacy:green_cultivator \
 \
 frights_and_foliage:spooky_campfire frights_and_foliage:spooky_lantern frights_and_foliage:spooky_torch \
 \
+hbm:tile.lamp_tritium_green_on hbm:tile.mush hbm:tile.mush_block_stem hbm:tile.waste_mycelium hbm:tile.brick_jungle_ooze \
+\
 hearth_and_home:green_paper_lantern \
 \
 mcwlights:green_ceiling_light mcwlights:green_lamp mcwlights:green_paper_lamp \
@@ -960,6 +968,8 @@ create_enchantment_industry:super_experience_block \
 createframed:framed_radon_lamp_cyan \
 \
 fossilslegacy:cyan_cultivator \
+\
+hbm:tile.lamp_tritium_blue_on hbm:tile.lamp_demon hbm:tile.hev_battery \
 \
 hearth_and_home:cyan_paper_lantern \
 \
@@ -1196,6 +1206,8 @@ createframed:framed_radon_lamp_pink \
 \
 fossilslegacy:pink_cultivator \
 \
+hbm:tile.brick_jungle_mystic \
+\
 hearth_and_home:pink_paper_lantern \
 \
 iceandfire:pixie_jar_0 \
@@ -1259,6 +1271,8 @@ dimdoors:decayed_block dimdoors:unfolded_block dimdoors:unravelled_block dimdoor
 enderio:light \
 \
 fossilslegacy:black_cultivator fossilslegacy:gray_cultivator fossilslegacy:light_gray_cultivator fossilslegacy:white_cultivator \
+\
+hbm:tile.spotlight_fluoro hbm:tile.spotlight_halogen \
 \
 hearth_and_home:black_paper_lantern hearth_and_home:gray_paper_lantern hearth_and_home:light_gray_paper_lantern hearth_and_home:white_paper_lantern \
 \
@@ -1888,6 +1902,8 @@ traveloptics:gauntlet_of_extinction traveloptics:harbingers_wrath traveloptics:i
 item.45084 = echo_shard recovery_compass music_disc_5 \
 \
 cataclysm:cursed_bow cataclysm:soul_render cataclysm:the_annihilator cataclysm:wrath_of_the_desert \
+\
+etfuturum:five_record \
 \
 fixedminecraft:echo_fruit fixedminecraft:echo_totem \
 \


### PR DESCRIPTION
Adds partial support for [Hbm's Nuclear Tech Mod](https://modrinth.com/mod/ntm) and [NTM: Space](https://modrinth.com/mod/ntmspace), as well as a few touchups on my previous PR

Something I'd like to point out is that blocks 10207, 10215, and 10223 seem to have incorrect names.