### PR TITLE
Add nbt distinction between flower_pot contents

### DIFF
--- a/blockProperties/1.7.10/block.properties
+++ b/blockProperties/1.7.10/block.properties
@@ -1482,15 +1482,15 @@ lotr:tile.mordorGravel lotr:tile.obsidianGravel lotr:tile.slabDoubleGravel
 block.10725 = lotr:tile.slabSingleGravel
 
 # Flower Pot - No Subsurface Scattering
-block.10729 = flower_pot \
+block.10729 = flower_pot[Item=minecraft:cactus] flower_pot[Item=minecraft:brown_mushroom] flower_pot[Item=minecraft:red_mushroom] \
 \
 lotr:tile.flowerPot
 
 # Flower Pot - Subsurface Scattering
-block.10733 =
+block.10733 = flower_pot[Item=minecraft:sapling] flower_pot[Item=minecraft:tallgrass] flower_pot[Item=minecraft:deadbush]
 
 # Flower Pot - Subsurface Scattering, Flowers - Euphoria Patches Emissive Flowers
-block.10735 =
+block.10735 = flower_pot[Item=minecraft:red_flower] flower_pot[Item=minecraft:yellow_flower]
 
 # Jigsaw Block
 block.10736 =


### PR DESCRIPTION
nbt matching was merged, this should fix flower pots for 1.7.10. Et Futurum: Requium should also be looked at again to see if nbt matching is needed there too.