### PR TITLE
Add supplementaries lit sconce lever to the campfire block property to match coloured lighting with regular lit sconce

### DIFF
--- a/blockProperties/1.13+/block.10605-10736.properties
+++ b/blockProperties/1.13+/block.10605-10736.properties
@@ -375,7 +375,7 @@ netherexp:burning_skull_block netherexp:burning_wither_skull_block \
 \
 spelunkery:mineomite:primed=true \
 \
-supplementaries:fire_pit:lit=true supplementaries:sconce:lit=true supplementaries:sconce_glow:lit=true supplementaries:sconce_nether_brass:lit=true supplementaries:sconce_wall:lit=true supplementaries:sconce_wall_glow:lit=true supplementaries:sconce_wall_nether_brass:lit=true \
+supplementaries:fire_pit:lit=true supplementaries:sconce:lit=true supplementaries:sconce_lever:lit=true supplementaries:sconce_glow:lit=true supplementaries:sconce_nether_brass:lit=true supplementaries:sconce_wall:lit=true supplementaries:sconce_wall_glow:lit=true supplementaries:sconce_wall_nether_brass:lit=true \
 \
 tfc:charcoal_forge tfc:firepit:lit=true tfc:grill:lit=true tfc:pot:lit=true tfc:stove:lit=true tfc:stove_pot:lit=true
 

--- a/blockProperties/1.13+/block.5000-10079.properties
+++ b/blockProperties/1.13+/block.5000-10079.properties
@@ -1545,7 +1545,7 @@ enderio:resetting_lever_five enderio:resetting_lever_five_inv enderio:resetting_
 \
 securitycraft:reinforced_lever \
 \
-supplementaries:crank supplementaries:sconce:lit=false supplementaries:sconce_ender:lit=false supplementaries:sconce_glow:lit=false supplementaries:sconce_green:lit=false supplementaries:sconce_lever supplementaries:sconce_nether_brass:lit=false supplementaries:sconce_soul:lit=false supplementaries:sconce_wall:lit=false supplementaries:sconce_wall_ender:lit=false supplementaries:sconce_wall_glow:lit=false supplementaries:sconce_wall_green:lit=false supplementaries:sconce_wall_nether_brass:lit=false supplementaries:sconce_wall_soul:lit=false \
+supplementaries:crank supplementaries:sconce:lit=false supplementaries:sconce_ender:lit=false supplementaries:sconce_glow:lit=false supplementaries:sconce_green:lit=false supplementaries:sconce_lever:list=false supplementaries:sconce_nether_brass:lit=false supplementaries:sconce_soul:lit=false supplementaries:sconce_wall:lit=false supplementaries:sconce_wall_ender:lit=false supplementaries:sconce_wall_glow:lit=false supplementaries:sconce_wall_green:lit=false supplementaries:sconce_wall_nether_brass:lit=false supplementaries:sconce_wall_soul:lit=false \
 \
 yogmod:classic_lever yogmod:lever
 

--- a/item.properties
+++ b/item.properties
@@ -309,7 +309,7 @@ quark:blaze_lantern \
 \
 securitycraft:reinforced_lantern \
 \
-supplementaries:sconce supplementaries:sconce_glow supplementaries:sconce_nether_brass supplementaries:wall_lantern \
+supplementaries:sconce supplementaries:sconce_lever supplementaries:sconce_glow supplementaries:sconce_nether_brass supplementaries:wall_lantern \
 \
 suppsquared:brass_lantern suppsquared:copper_lantern \
 \


### PR DESCRIPTION
This brings the sconce lever in line with the regular sconce so they can be used together without coloured lighting getting messed up. ALso adds the sconce lever to the same item property group as the sconce for handheld lighting.
Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e54c4475-5470-4e35-85a5-26d295e49d7c" />

After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/139094c2-5ed1-4bb8-9ee4-91583ff78602" />

