### PR TITLE
Clear item definitions for block.21040

### DIFF
--- a/blockProperties/1.13+/block.10944-21044.properties
+++ b/blockProperties/1.13+/block.10944-21044.properties
@@ -1444,8 +1444,7 @@ block.21036 =
 block.21038 =
 
 # Cyan Emissive Blocks
-block.21040 = puremashtweaks:alchemical_synthesizer puremashtweaks:moldelonian_block puremashtweaks:multifunctional_compressor puremashtweaks:puremash_core_block puremashtweaks:synthesis_table puremashtweaks:synthorium_block puremashtweaks:chunk_loader puremashtweaks:fluid_tank puremashtweaks:creative_fluid_tank
-
+block.21040 = 
 # Light Blue Emissive Blocks
 block.21042 =
 


### PR DESCRIPTION
Removal of PureMash Tweaks blocks from the fully emissive cyan blocks category.